### PR TITLE
feat: add tp_init re-init safety and tp_new uninitialized state detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `init_not_reinit_safe` finding: detect tp_init functions that allocate without re-init guards.
+- `new_missing_member_init` finding: detect tp_new functions using non-zeroing allocators without member initialization.
 - Initial implementation of cpython-review-toolkit plugin.
 - 7 analysis scripts: analyze_includes, measure_c_complexity, check_pep7, scan_refcounts, scan_error_paths, scan_null_checks, scan_gil_usage.
 - 10 agent definitions: refcount-auditor, error-path-analyzer, gil-discipline-checker, c-complexity-analyzer, include-graph-mapper, pep7-style-checker, null-safety-scanner, api-deprecation-tracker, macro-hygiene-reviewer, memory-pattern-analyzer.

--- a/plugins/cpython-review-toolkit/agents/refcount-auditor.md
+++ b/plugins/cpython-review-toolkit/agents/refcount-auditor.md
@@ -56,7 +56,25 @@ For each candidate finding from the script:
    - Likely bug but uncertain due to complex flow → CONSIDER
    - False positive → skip (don't report)
 
-### Phase 3: Pattern-Based Review
+### Phase 3: tp_init / tp_new Safety Review
+
+The script also checks for two underappreciated bug classes:
+
+**`init_not_reinit_safe`**: A `tp_init` function that allocates resources and assigns to `self->member` without a re-init guard. Python allows `obj.__init__()` to be called multiple times — if `tp_init` doesn't check for prior initialization or clean up existing state first, the second call leaks the first call's resources.
+
+For each finding:
+1. Read the `tp_init` function and check whether re-init is actually possible (some types are immutable or reject re-init at the Python level)
+2. Check for guards the script may have missed: flag-based (`self->initialized`), error-based (`"already initialized"`), or cleanup-based (`if (self->field != NULL) { Py_CLEAR(self->field); }`)
+3. Classify: **FIX** if allocation + member assignment with no guard, **ACCEPTABLE** if any guard is present or re-init is prevented at a higher level
+
+**`new_missing_member_init`**: A `tp_new` function that uses a non-zeroing allocator (`PyObject_New`, `PyObject_GC_New`, `malloc`) without initializing pointer members to NULL. If `object.__new__(MyType)` is called without `__init__()`, methods may dereference uninitialized garbage.
+
+For each finding:
+1. Check which allocator is used — `tp_alloc`/`PyType_GenericAlloc`/`calloc` zero memory and are safe
+2. If a non-zeroing allocator is used, check if all pointer members are explicitly set to NULL/0
+3. Classify: **CONSIDER** if non-zeroing without member init, **ACCEPTABLE** if zeroing allocator or explicit init
+
+### Phase 4: Pattern-Based Review
 
 Beyond script findings, look for these patterns in the code:
 
@@ -80,6 +98,16 @@ Beyond script findings, look for these patterns in the code:
 **What**: New reference from `API_NAME` assigned to `var` is not DECREF'd on error path (line N returns NULL).
 **Why it matters**: This leaks memory on every error in this code path.
 **Fix**: Add `Py_XDECREF(var)` to the error cleanup label, or use `Py_CLEAR(var)` if `var` is reachable from a GC-traversable object.
+
+#### [FIX] tp_init not re-init safe in `MyObj_init` (file.c:line)
+**What**: `MyObj_init` allocates via `PyList_New` and assigns to `self->data` without checking for prior initialization.
+**Why it matters**: If `__init__()` is called twice, the first call's `self->data` is leaked.
+**Fix**: Either reject re-init (`if (self->initialized) { PyErr_SetString(...); return -1; }`) or clean up first (`Py_CLEAR(self->data)` before reassigning).
+
+#### [CONSIDER] tp_new leaves members uninitialized in `MyObj_new` (file.c:line)
+**What**: `MyObj_new` uses `PyObject_New` (non-zeroing) without setting `self->data` and `self->buffer` to NULL.
+**Why it matters**: `object.__new__(MyObj)` without `__init__()` leaves garbage pointers that methods will dereference.
+**Fix**: Either use `type->tp_alloc(type, 0)` (zeroing), or explicitly set all pointer members to NULL after allocation.
 
 #### [CONSIDER] Borrowed reference use-after-possible-free in `function_name` (file.c:line)
 **What**: Borrowed reference from `PyList_GetItem` at line N is used after calling `PyObject_CallMethod` at line M, which could trigger GC and invalidate the borrowed reference.

--- a/plugins/cpython-review-toolkit/scripts/scan_refcounts.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_refcounts.py
@@ -256,6 +256,179 @@ _GOTO_ERROR_RE = re.compile(r'\bgoto\s+(\w+)\s*;')
 _ERROR_LABEL_RE = re.compile(r'^(\w+)\s*:', re.MULTILINE)
 
 
+# ---------------------------------------------------------------------------
+# tp_init / tp_new detection
+# ---------------------------------------------------------------------------
+
+# Allocation APIs that create resources (superset of NEW_REF_APIS for init
+# safety — includes raw memory and file handles).
+_INIT_ALLOC_APIS = frozenset({
+    "PyMem_Malloc", "PyMem_Calloc", "PyMem_Realloc",
+    "malloc", "calloc", "realloc",
+    "PyObject_New", "PyObject_GC_New",
+    "PyList_New", "PyDict_New", "PyTuple_New", "PySet_New",
+    "PyUnicode_FromString", "PyBytes_FromString",
+    "Py_BuildValue", "PyObject_Call", "PyObject_CallFunction",
+    "PyObject_CallMethod",
+    "fopen", "open",
+})
+
+_INIT_ALLOC_RE = re.compile(
+    r'\b(' + '|'.join(
+        re.escape(api) for api in sorted(_INIT_ALLOC_APIS, key=len, reverse=True)
+    ) + r')\s*\('
+)
+
+# Assignment to self->member pattern.
+_SELF_MEMBER_ASSIGN_RE = re.compile(
+    r'\bself\s*->\s*(\w+)\s*='
+)
+
+# Re-init guard patterns (any of these → safe).
+_REINIT_GUARD_PATTERNS = [
+    re.compile(r'"already.?init', re.IGNORECASE),
+    re.compile(r'"cannot.?reinit', re.IGNORECASE),
+    re.compile(r'\bPREVENT_INIT', re.IGNORECASE),
+    re.compile(r'\binit_was_called\b'),
+    re.compile(r'\bself\s*->\s*initialized\b'),
+    # Cleanup-before-assign: if (self->member != NULL) { Py_CLEAR/free/DECREF }
+    re.compile(
+        r'if\s*\(\s*self\s*->\s*\w+\s*!=\s*NULL\s*\)'
+        r'[^}]*(?:Py_CLEAR|Py_XDECREF|Py_DECREF|PyMem_Free|free)\s*\('
+    ),
+]
+
+# Non-zeroing allocators for tp_new.
+_NON_ZEROING_ALLOC_RE = re.compile(
+    r'\b(PyObject_New|PyObject_GC_New|malloc)\s*\('
+)
+
+# Zeroing allocators for tp_new.
+_ZEROING_ALLOC_RE = re.compile(
+    r'\b(tp_alloc|PyType_GenericAlloc|calloc)\s*\(|'
+    r'\bmemset\s*\(\s*self\s*,\s*0'
+)
+
+# Member init to NULL/0 in tp_new.
+_MEMBER_NULL_INIT_RE = re.compile(
+    r'\bself\s*->\s*\w+\s*=\s*(?:NULL|0)\s*;'
+)
+
+
+def _is_tp_init(func: dict) -> bool:
+    """Check if a function looks like a tp_init implementation.
+
+    tp_init signature: int SomeType_init(SomeType *self, PyObject *args, ...)
+    """
+    name = func["name"]
+    body = func["body"]
+    # Name typically ends with _init or _Init.
+    if not re.search(r'_[Ii]nit$', name):
+        return False
+    # Body should reference self-> (operates on instance).
+    if 'self->' not in body:
+        return False
+    return True
+
+
+def _is_tp_new(func: dict) -> bool:
+    """Check if a function looks like a tp_new implementation.
+
+    tp_new signature: PyObject *SomeType_new(PyTypeObject *type, ...)
+    """
+    name = func["name"]
+    body = func["body"]
+    if not re.search(r'_[Nn]ew$', name):
+        return False
+    # Should contain an allocator call and return a PyObject*.
+    if 'self' not in body:
+        return False
+    return True
+
+
+def check_init_reinit_safety(func: dict) -> list[dict]:
+    """Check a tp_init function for re-init safety issues.
+
+    Flags tp_init functions that allocate resources and assign to
+    self->member without a re-init guard.
+    """
+    if not _is_tp_init(func):
+        return []
+
+    body = func["body"]
+    clean = strip_comments_and_strings(body)
+    findings: list[dict] = []
+
+    # Check for allocations.
+    alloc_calls = _INIT_ALLOC_RE.findall(clean)
+    if not alloc_calls:
+        return []
+
+    # Check for self->member assignments.
+    member_assigns = _SELF_MEMBER_ASSIGN_RE.findall(clean)
+    if not member_assigns:
+        return []
+
+    # Check for re-init guard patterns.
+    for pattern in _REINIT_GUARD_PATTERNS:
+        if pattern.search(clean):
+            return []
+
+    # No guard found — flag it.
+    findings.append({
+        "type": "init_not_reinit_safe",
+        "line_offset": 0,
+        "detail": (
+            f"tp_init '{func['name']}' allocates ({', '.join(sorted(set(alloc_calls)))}) "
+            f"and assigns to self->{', self->'.join(sorted(set(member_assigns)))} "
+            f"without a re-init guard — second __init__() call will leak resources"
+        ),
+        "confidence": "high",
+    })
+    return findings
+
+
+def check_new_member_init(func: dict) -> list[dict]:
+    """Check a tp_new function for uninitialized member safety.
+
+    Flags tp_new functions using non-zeroing allocators without
+    initializing pointer members to NULL.
+    """
+    if not _is_tp_new(func):
+        return []
+
+    body = func["body"]
+    clean = strip_comments_and_strings(body)
+    findings: list[dict] = []
+
+    # Check if a zeroing allocator is used — if so, safe.
+    if _ZEROING_ALLOC_RE.search(clean):
+        return []
+
+    # Check if a non-zeroing allocator is used.
+    non_zero_m = _NON_ZEROING_ALLOC_RE.search(clean)
+    if not non_zero_m:
+        return []
+
+    allocator = non_zero_m.group(1)
+
+    # Check if pointer members are explicitly initialized.
+    if _MEMBER_NULL_INIT_RE.search(clean):
+        return []
+
+    findings.append({
+        "type": "new_missing_member_init",
+        "line_offset": clean[:non_zero_m.start()].count('\n') + 1,
+        "detail": (
+            f"tp_new '{func['name']}' uses non-zeroing allocator {allocator}() "
+            f"without initializing pointer members to NULL — "
+            f"object.__new__() without __init__() will leave garbage pointers"
+        ),
+        "confidence": "medium",
+    })
+    return findings
+
+
 def analyze_function_refcounts(func: dict) -> list[dict]:
     """Analyze refcount balance for a single function.
 
@@ -413,7 +586,12 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
         functions = find_functions(source)
         for func in functions:
             functions_analyzed += 1
+            # Standard refcount analysis.
             func_findings = analyze_function_refcounts(func)
+            # tp_init re-init safety.
+            func_findings.extend(check_init_reinit_safety(func))
+            # tp_new uninitialized member safety.
+            func_findings.extend(check_new_member_init(func))
             for finding in func_findings:
                 finding["file"] = rel
                 finding["function"] = func["name"]
@@ -423,6 +601,8 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
     # Categorize findings.
     leaks = [f for f in all_findings if "leak" in f["type"]]
     double_frees = [f for f in all_findings if "double_free" in f["type"]]
+    reinit = [f for f in all_findings if f["type"] == "init_not_reinit_safe"]
+    new_uninit = [f for f in all_findings if f["type"] == "new_missing_member_init"]
 
     return {
         "project_root": str(project_root),
@@ -433,6 +613,8 @@ def analyze(target: str, *, max_files: int = 0) -> dict:
         "summary": {
             "potential_leaks": len(leaks),
             "potential_double_frees": len(double_frees),
+            "init_not_reinit_safe": len(reinit),
+            "new_missing_member_init": len(new_uninit),
             "total_findings": len(all_findings),
             "high_confidence": len(
                 [f for f in all_findings if f.get("confidence") == "high"]

--- a/tests/test_scan_refcounts.py
+++ b/tests/test_scan_refcounts.py
@@ -103,6 +103,218 @@ class TestRefcountDetection(unittest.TestCase):
             self.assertEqual(len(leaks), 0)
 
 
+class TestInitReinitSafety(unittest.TestCase):
+    """Test tp_init re-init safety detection."""
+
+    def test_detects_unsafe_reinit(self):
+        c_code = (
+            "static int\n"
+            "MyObj_init(MyObj *self, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    self->data = PyList_New(0);\n"
+            "    self->buffer = PyMem_Malloc(1024);\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            reinit = [
+                f for f in result["findings"]
+                if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 1)
+            self.assertIn("MyObj_init", reinit[0]["detail"])
+            self.assertEqual(reinit[0]["confidence"], "high")
+
+    def test_safe_reinit_flag_guard(self):
+        c_code = (
+            "static int\n"
+            "MyObj_init(MyObj *self, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    if (self->initialized) {\n"
+            '        PyErr_SetString(PyExc_RuntimeError, "already initialized");\n'
+            "        return -1;\n"
+            "    }\n"
+            "    self->data = PyList_New(0);\n"
+            "    self->initialized = 1;\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            reinit = [
+                f for f in result["findings"]
+                if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 0)
+
+    def test_safe_reinit_cleanup_guard(self):
+        c_code = (
+            "static int\n"
+            "MyObj_init(MyObj *self, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    if (self->data != NULL) {\n"
+            "        Py_CLEAR(self->data);\n"
+            "    }\n"
+            "    self->data = PyList_New(0);\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            reinit = [
+                f for f in result["findings"]
+                if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 0)
+
+    def test_safe_reinit_prevent_macro(self):
+        c_code = (
+            "static int\n"
+            "MyObj_init(MyObj *self, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    PREVENT_INIT_MULTIPLE_CALLS;\n"
+            "    self->data = PyList_New(0);\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            reinit = [
+                f for f in result["findings"]
+                if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 0)
+
+    def test_no_alloc_no_finding(self):
+        c_code = (
+            "static int\n"
+            "MyObj_init(MyObj *self, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    self->count = 0;\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            reinit = [
+                f for f in result["findings"]
+                if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 0)
+
+    def test_non_init_function_ignored(self):
+        c_code = (
+            "static int\n"
+            "MyObj_setup(MyObj *self, PyObject *args)\n"
+            "{\n"
+            "    self->data = PyList_New(0);\n"
+            "    return 0;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            reinit = [
+                f for f in result["findings"]
+                if f["type"] == "init_not_reinit_safe"
+            ]
+            self.assertEqual(len(reinit), 0)
+
+
+class TestNewWithoutInit(unittest.TestCase):
+    """Test tp_new uninitialized member detection."""
+
+    def test_detects_non_zeroing_no_init(self):
+        c_code = (
+            "static PyObject *\n"
+            "MyObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    MyObj *self = (MyObj *)PyObject_New(MyObj, type);\n"
+            "    return (PyObject *)self;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            uninit = [
+                f for f in result["findings"]
+                if f["type"] == "new_missing_member_init"
+            ]
+            self.assertEqual(len(uninit), 1)
+            self.assertIn("PyObject_New", uninit[0]["detail"])
+
+    def test_safe_zeroing_allocator(self):
+        c_code = (
+            "static PyObject *\n"
+            "MyObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    MyObj *self = (MyObj *)type->tp_alloc(type, 0);\n"
+            "    return (PyObject *)self;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            uninit = [
+                f for f in result["findings"]
+                if f["type"] == "new_missing_member_init"
+            ]
+            self.assertEqual(len(uninit), 0)
+
+    def test_safe_explicit_null_init(self):
+        c_code = (
+            "static PyObject *\n"
+            "MyObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    MyObj *self = (MyObj *)PyObject_New(MyObj, type);\n"
+            "    if (self != NULL) {\n"
+            "        self->data = NULL;\n"
+            "        self->buffer = NULL;\n"
+            "    }\n"
+            "    return (PyObject *)self;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            uninit = [
+                f for f in result["findings"]
+                if f["type"] == "new_missing_member_init"
+            ]
+            self.assertEqual(len(uninit), 0)
+
+    def test_safe_generic_alloc(self):
+        c_code = (
+            "static PyObject *\n"
+            "MyObj_new(PyTypeObject *type, PyObject *args, PyObject *kwds)\n"
+            "{\n"
+            "    MyObj *self = (MyObj *)PyType_GenericAlloc(type, 0);\n"
+            "    return (PyObject *)self;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            uninit = [
+                f for f in result["findings"]
+                if f["type"] == "new_missing_member_init"
+            ]
+            self.assertEqual(len(uninit), 0)
+
+    def test_non_new_function_ignored(self):
+        c_code = (
+            "static PyObject *\n"
+            "MyObj_create(PyTypeObject *type, PyObject *args)\n"
+            "{\n"
+            "    MyObj *self = (MyObj *)PyObject_New(MyObj, type);\n"
+            "    return (PyObject *)self;\n"
+            "}\n"
+        )
+        with TempProject({"Objects/test.c": c_code}) as root:
+            result = mod.analyze(str(root))
+            uninit = [
+                f for f in result["findings"]
+                if f["type"] == "new_missing_member_init"
+            ]
+            self.assertEqual(len(uninit), 0)
+
+
 class TestAnalyze(unittest.TestCase):
     """Test full refcount analysis."""
 
@@ -120,6 +332,8 @@ class TestAnalyze(unittest.TestCase):
             self.assertIn("summary", result)
             self.assertIn("potential_leaks", result["summary"])
             self.assertIn("potential_double_frees", result["summary"])
+            self.assertIn("init_not_reinit_safe", result["summary"])
+            self.assertIn("new_missing_member_init", result["summary"])
             self.assertIn("total_findings", result["summary"])
 
     def test_empty_project(self):


### PR DESCRIPTION
## Summary
- Add `init_not_reinit_safe` finding to detect tp_init functions that allocate without re-init guards (leaks on second `__init__()` call)
- Add `new_missing_member_init` finding to detect tp_new functions using non-zeroing allocators without initializing pointer members (garbage pointers if `__new__()` called without `__init__()`)
- Update refcount-auditor agent with Phase 3 covering these patterns and output format examples

## Test plan
- [x] All 72 tests pass (61 original + 11 new)
- [x] Detects unsafe tp_init (allocates + assigns to self->member, no guard)
- [x] Recognizes safe tp_init: flag guard (`self->initialized`), cleanup guard (`Py_CLEAR`), error message guard (`"already initialized"`), macro guard (`PREVENT_INIT`)
- [x] Skips tp_init with no allocations (scalar-only init)
- [x] Ignores non-init functions (name doesn't end with `_init`)
- [x] Detects unsafe tp_new (PyObject_New without member init)
- [x] Recognizes safe tp_new: zeroing allocator (`tp_alloc`, `PyType_GenericAlloc`), explicit NULL init
- [x] Ignores non-new functions (name doesn't end with `_new`)
- [x] Summary includes new `init_not_reinit_safe` and `new_missing_member_init` counts

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)