### PR TITLE
v0.5: tree-sitter chassis + crash-class detectors + informed-explore/known-issues

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "cpython-review-toolkit",
-  "version": "0.4.0",
-  "description": "CPython C code exploration and analysis toolkit: 10 specialized agents for refcount auditing, error path analysis, GIL discipline checking, complexity measurement, include graph mapping, PEP 7 style checking, NULL safety scanning, API deprecation tracking, macro hygiene review, and memory pattern analysis.",
+  "version": "0.5.0",
+  "description": "CPython C code exploration and analysis toolkit: specialized agents for refcount auditing, error path analysis, GIL discipline, NULL safety, complexity, include-graph mapping, PEP 7 style, deprecation, macros, and memory patterns — plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
   "owner": {
     "name": "Danzin",
     "email": "lafleurfuzzer@gmail.com"
@@ -10,9 +10,9 @@
   "plugins": [
     {
       "name": "cpython-review-toolkit",
-      "description": "10 specialized agents and 4 commands for exploring, analyzing, and reviewing CPython's C source code. Includes analysis scripts for include graph mapping, C complexity measurement, refcount auditing, error path analysis, GIL usage scanning, PEP 7 style checking, and NULL safety scanning.",
+      "description": "Specialized agents and commands for exploring, analyzing, and reviewing CPython's C source code. Regex scanners for include-graph mapping, complexity, refcounts, error paths, GIL, and NULL safety, plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
       "source": "./plugins/cpython-review-toolkit",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "category": "code-quality",
       "keywords": [
         "cpython",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,55 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.5.0] - 2026-07-24
+
+The chassis-and-crash-classes release. Adopts a tree-sitter-C parsing chassis
+(shared with the cext/ft siblings) and adds the first crash-class detectors
+grounded in the fusil OOM/TSan findings repos and the CPython tracker, plus the
+informed-explore and known-issues workflow machinery.
+
+### Added
+- **Tree-sitter-C chassis**: vendored `tree_sitter_utils.py` (verbatim from the
+  cext sibling) and a CPython-adapted `scan_common.py` (`find_cpython_root`,
+  `resolve_roots`, `discover_c_files`, `parse_common_args`, `build_report`,
+  comment-based suppression, dedup). New scanners parse real function boundaries
+  instead of regex. Requires `pip install tree-sitter tree-sitter-c`.
+- **recursion-guard-auditor** + `scan_recursion_guards.py`: recursion-prone slots
+  (`tp_hash`/`tp_richcompare`/`tp_repr`/`tp_str`, generic-alias parameter walks)
+  that descend a user-controlled object graph without `Py_EnterRecursiveCall` /
+  `Py_ReprEnter` → native-stack-overflow SIGSEGV. Validates against gh-154318
+  (`tuple_hash`) and gh-154275 (`_Py_make_parameters`).
+- **pyerr-clear-auditor** + `scan_pyerr_clear.py`: `PyErr_Clear()` in the
+  destructor family (`tp_dealloc`/`tp_clear`/`tp_finalize`/`tp_traverse`) with no
+  save/restore, swallowing an in-flight `MemoryError`/`KeyboardInterrupt`.
+  Validates against `deque_clear` and gh-152083 (`context_tp_dealloc`).
+- **uninitialized-dealloc-auditor** + `scan_uninit_dealloc.py`: non-zeroing
+  allocation freed on an error path before members are initialized → `tp_dealloc`
+  reads garbage. Validates against gh-151815 (`template_iter`).
+- **known-issues** command + `check_known_issues.py`: cross-references
+  `data/cpython_known_bugs.tsv` (seeded from cpython-oom-findings /
+  cpython-tsan-findings / the tracker) against a fresh scan.
+- **informed-explore** command + `build_informed_briefing.py`: a catalog-seeded
+  targeted pass driven by `data/cpython_bug_shapes.json` (guarded-twin / hunt /
+  differential) and `data/cpython_non_bugs.md` (FP taxonomy), with a
+  `--catalog-dir` hook into a `cpython-review-findings` repo.
+- **git-history-context** preflight agent: an early per-file bug-fix-density
+  watchlist (distinct from the post-hoc `git-history-analyzer`), with
+  shallow-clone detection.
+- **`data/` layer**: `cpython_known_bugs.tsv`, `cpython_bug_shapes.json`,
+  `cpython_reachability_sources.json`, `cpython_non_bugs.md`.
+- `docs/improvement-plan.md`: the v0.5+ roadmap this release begins executing.
+
+### Changed
+- `explore` command wires the three new crash-class detectors (Group A2) and adds
+  the `recursion`, `pyerr-clear`, and `uninit-dealloc` aspects.
+- Version → 0.5.0 across both manifests.
+
+## [0.4.0]
+
+Everything shipped through 0.4.0 (previously tracked under `[Unreleased]`).
 
 ### Enhanced
 - `analyze_history.py`: parallelize git subprocess calls using `ThreadPoolExecutor` for ~4-8x speedup on diff extraction. Add `--workers N` option (default 8).

--- a/README.md
+++ b/README.md
@@ -34,29 +34,30 @@ claude --plugin-dir cpython-review-toolkit/plugins/cpython-review-toolkit
 Navigate to a CPython source checkout, then:
 
 ```bash
-/cpython-review-toolkit:map        # Understand include structure
-/cpython-review-toolkit:health     # Quick health dashboard
-/cpython-review-toolkit:hotspots   # Refcount leaks + error bugs + complexity
-/cpython-review-toolkit:explore    # Full exploration (all 10 agents)
+/cpython-review-toolkit:map            # Understand include structure
+/cpython-review-toolkit:health         # Quick health dashboard
+/cpython-review-toolkit:hotspots       # Crash-class detectors + refcount + complexity
+/cpython-review-toolkit:explore        # Full exploration (all agents)
+/cpython-review-toolkit:known-issues   # Regression check vs the known-crash catalog
 ```
 
 Start with `map` to understand the include graph, then `hotspots` to find the highest-impact bugs.
 
 ## What's Included
 
-- **10 analysis agents** covering reference counting, error handling, GIL discipline, complexity, NULL safety, PEP 7 style, include dependencies, API deprecation, macro hygiene, and memory patterns.
-- **4 commands** (`explore`, `map`, `hotspots`, `health`) for different analysis workflows.
-- **7 analysis scripts** (stdlib-only Python) for include graphing, complexity measurement, refcount scanning, error path analysis, NULL safety checking, GIL usage scanning, and PEP 7 style checking.
+- **15 analysis agents** covering reference counting, error handling, GIL discipline, complexity, NULL safety, PEP 7 style, include dependencies, API deprecation, macro hygiene, memory patterns, and temporal history — plus tree-sitter-based **crash-class detectors** for recursion-guard gaps, destructor exception-clobber, and uninitialized-dealloc.
+- **6 commands** (`explore`, `informed-explore`, `known-issues`, `map`, `hotspots`, `health`) for different analysis workflows.
+- **Analysis scripts** — stdlib-only regex scanners for the legacy dimensions, plus tree-sitter crash-class detectors, a `known-issues` regression checker, and an `informed-explore` briefing generator.
 
 ## Prerequisites
 
 - **Claude Code** installed and running.
-- **Python 3.10+** for the analysis scripts (type syntax from 3.10+).
-- No third-party packages — all scripts use only the standard library.
+- **Python 3.10+** for the analysis scripts.
+- **tree-sitter + tree-sitter-c** (`pip install tree-sitter tree-sitter-c`) for the crash-class detectors, `known-issues`, and `informed-explore`; the legacy scanners remain stdlib-only.
 
 ## How It Works
 
-The scripts use regex-based scanning to find candidate issues in C source files. This is intentionally imprecise — scripts identify candidates with an expected 30-50% false positive rate, and the agents read the actual code to confirm or dismiss each finding. This approach works well for CPython because PEP 7 makes the code style very regular and predictable.
+Two generations of scanner coexist: stdlib-only **regex scanners** for the legacy dimensions (refcounts, errors, NULL, GIL, complexity, PEP 7, includes), and **tree-sitter crash-class detectors** that parse a real C syntax tree to target specific reachable-from-Python crash classes (validated against confirmed CPython crashes). All scripts report candidates — expect 10-50% false positives depending on the detector — and the agents read the actual code to confirm or dismiss each finding and classify it FIX / CONSIDER / POLICY / ACCEPTABLE.
 
 For detailed usage, agent descriptions, and recommended workflows, see the [plugin README](plugins/cpython-review-toolkit/README.md).
 

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -1,0 +1,267 @@
+# cpython-review-toolkit — Improvement Plan (toward v0.5+)
+
+> Status: proposal, 2026-07-24. Synthesized from four research streams: (1) a full
+> inventory of the current toolkit, (2) mining the fusil findings repos
+> (`cpython-oom-findings`, `cpython-tsan-findings`, `rustpython-findings`), (3) recent
+> CPython `type-crash` tracker issues, (4) transferable techniques from the sibling
+> toolkits (rustpy, cext, rust-ext, ft).
+>
+> **All file:line and issue anchors below were gathered on 2026-07-24 and should be
+> re-confirmed at implementation time** — CPython moves and line numbers drift.
+
+---
+
+## 1. Where the toolkit stands today
+
+`cpython-review-toolkit` is **v0.4.0** in its manifests but is the family's least-built-out
+member. It is a purely-static, regex-based, single-pass reviewer:
+
+- **11 agents, 8 scripts, 4 commands (`explore`/`map`/`hotspots`/`health`), 110 tests.**
+- **No shared tree-sitter chassis.** Every script is stdlib-only regex; `find_cpython_root()`
+  is copy-duplicated across all 8. There is no `tree_sitter_utils.py` / `scan_common.py`.
+- **No `data/` directory.** Every table (deprecated APIs, refcount semantics, fallible-API
+  list) is inlined as prose inside agent prompts — nothing is machine-readable or refreshable
+  from a CPython tree.
+- **3 of the 11 agents are script-less** (memory-pattern, macro-hygiene, api-deprecation are
+  qualitative Grep-only, with no tests).
+
+What it already has that we can build on:
+
+- A **manual** dynamic-verification track: `reports/reproducers/` holds ~18 hand-authored
+  Python reproducers (grouper reentrancy, ctypes overflow, zstd refleak, sentinel UAF, …) —
+  evidence the analyze→reproduce loop already happens by hand, but **nothing in the plugin
+  reads, writes, or regression-checks against them.**
+- `docs/python-wrapper-new-without-init.md` — a complete design for an **unbuilt** init-bypass
+  rule (currently routed *out of house* to cext/code-review).
+- The user's own campaign has already produced upstream umbrella issues **#151763** (OOM: 31
+  distinct finds), **#153852** (FT: 15 races), **#146102** (toolkit umbrella) — i.e. a proven
+  supply of ground-truth bugs to calibrate against.
+
+### Capability gaps vs. the siblings (the map of the opportunity)
+
+| Capability | rustpy | cext | rust-ext | ft | **cpython** |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Shared tree-sitter chassis | ✅ | ✅ | ✅ | ✅ | ❌ (regex only) |
+| `data/` JSON tables | ✅ | ✅ | ✅ | ✅ | ❌ (prose-inlined) |
+| Preflight orientation mapper | ✅ | ✅ | ✅ | — | ⚠️ include-graph only |
+| Early history-context preflight | — | — | — | — | ❌ (history runs last only) |
+| Informed-explore loop | ✅ | ✅ | ✅ | — | ❌ |
+| known-issues regression command | ✅ | — | — | — | ❌ |
+| Findings-repo feedback loop | ✅ | ✅ | ✅ | — | ❌ |
+| Reproducer / dynamic harness | — | ✅ (doc) | — | ✅ | ❌ (manual only) |
+| Reachability-tiering (S/N control) | ✅ | ⚠️ | ⚠️ | — | ❌ |
+| Free-threading / TSan detection | ⚠️ | — | — | ✅ | ❌ |
+| Recursion-guard detection | ✅ | — | ✅ | — | ❌ |
+| C-vs-Python parity | — | ✅ | ✅ | — | ❌ |
+
+---
+
+## 2. The core insight
+
+The toolkit's **own fuzzing siblings and the CPython tracker are a ready-made, high-signal
+catalog of exactly the bug classes a static reviewer should catch — and most are uncovered.**
+Three research streams independently converged on the same short list of classes. The plan has
+three levers:
+
+- **A. New detectors** for the uncovered classes (recursion-guard, FT races, uninit-dealloc,
+  exception-clobber-in-dealloc, OOM-alloc, init-bypass).
+- **B. Loop-closing machinery** — informed-explore, known-issues, a reproducer harness, and a
+  findings-repo tie-in — so the fuzz→static→reproduce→regression cycle is a *loop*, not a
+  one-shot scan.
+- **C. Infrastructure** — a chassis decision, a `data/` layer, and reachability-tiering — to
+  keep signal/noise usable at CPython scale (the candidate count is inherently huge).
+
+---
+
+## 3. Tier 1 — New detection capabilities (biggest coverage gaps)
+
+Ranked by (value × static-detectability × how uncovered it is). Every row is corroborated by
+≥2 of the research streams.
+
+| # | New/changed scanner + agent | Class | Concrete static signal | Evidence anchors | Port from |
+|---|---|---|---|---|---|
+| **1.1** | **`scan_recursion_guards.py`** + `recursion-guard-auditor` (NEW) | Unguarded native recursion in a recursive `tp_` slot → C-stack SIGSEGV | A fn wired to `tp_hash`/`tp_richcompare`/`tp_repr`/`tp_traverse` (or named `*_hash`/`*_repr`/`make_parameters`) that self-recurses or descends into `PyObject_Hash`/`Repr`/`GET_ITEM` with **no** `Py_EnterRecursiveCall`/`Py_ReprEnter` in its text | #154318 (`tuple_hash`,`frozendict_hash` — noted *copy-pasted* guardless), #154275 (`_Py_make_parameters`), #149146 (`tuple_dealloc`) | rustpy `recursion-guard-auditor`, rust-ext recursion agent |
+| **1.2** | **`scan_ft_races.py`** + `ft-race-scanner` (NEW) — the richest single seam | Free-threading data races in CPython's own C | Three sub-rules: **T3** iterator-exhaustion double-DECREF (`it->seq=NULL; Py_DECREF(seq)` outside a critical section — fixed template, ~zero FP); **T2** lazy-init without CS (`if(!self->f) self->f=…` with no `Py_BEGIN_CRITICAL_SECTION`); **T1** atomic/plain access asymmetry (same `x->field` via `FT_ATOMIC_*` at one site, plain at another) | T3: #154130, #144357, #153296, #154535; T2: #154527; T1: `itertoolsmodule.c` count_repr, #153852 cluster | ft `lock-discipline-checker`, `atomic-candidate-finder`; new intra-file field-access map |
+| **1.3** | **Extend `scan_refcounts.py` `check_new_member_init`** → `scan_uninit_dealloc.py` scope | Dealloc/clear of a half-constructed payload | Non-zeroing `*_New` (`PyObject_New`/`PyObject_GC_New`) + fields set only *after* a fallible call + an early error-return that decrefs; or `tp_clear`/`tp_dealloc` reading fields / `switch`ing an enum with `Py_UNREACHABLE()` default the ctor sets late | #151815 (`template_iter`), #152851 (`blake2 .copy()`), OOM-0024/0043, RUSTPY-0008 | own existing `check_new_member_init` (already the closest thing) |
+| **1.4** | **`scan_pyerr_clear_in_dealloc.py`** + agent (NEW) | Exception-clobber in destructors | `PyErr_Clear()` (or a dropped fallible call) inside `*_dealloc`/`*_clear`/`tp_finalize`/`*_traverse` **without** a surrounding `PyErr_Fetch`/`Restore` (or `PyErr_GetRaisedException`/`SetRaisedException`) save/restore | #152083 (`context_tp_dealloc`), `typeobject.c:2719`, `_collectionsmodule.c` `deque_clear` (OOM-0039) | **direct port of cext `pyerr-clear-auditor`**, scoped to destructor family |
+| **1.5** | **`scan_init_bypass.py`** + agent (NEW) — *design already exists in-repo* | Init-bypass / deletable slot → NULL field a C slot derefs | A slot reads `self->field` → `Py_INCREF`/`PyObject_Call*`/deref with no NULL guard, where the type has no `tp_new`/`DISALLOW_INSTANTIATION`, or the field is a settable/deletable member | #152954 (`sqlite3.Connection.__new__`), #152817 (`del cursor.row_factory`) | **build the already-written `docs/python-wrapper-new-without-init.md`** for the C side |
+| **1.6** | **Promote `memory-pattern-analyzer`** from script-less agent → real scanner `scan_memory_patterns.py` | (a) Integer overflow in alloc size; (b) GC-track invariant | (a) `PyMem_*`/`malloc(n * size)` where `n` is a `Py_ssize_t` from Python args with no `n > MAX/size` guard / no safe-multiply helper; (b) `PyObject_GC_UnTrack` reachable on a `tp_dealloc` error path where `GC_Track` may not have run | (a) #3493/#1779, RUSTPY huge-alloc; (b) #152107 (OOM-0006), OOM-0017 | own agent prose (currently un-automated) |
+| **1.7** | **Widen `scan_error_paths.py` / `scan_null_checks.py`** (tables + flow) | O1/O2/F fallible-return + cross-statement null | Add missing constructors to the fallible-API table (`PyStructSequence_New`, `PyUnicode_AsUTF8`, `_PyUnicode_FromUCS4`, import.c hashtable helpers); add **store-then-deref** (alloc stored into a field/local, deref'd on a distant later path); add **pending-exception desync** (`res!=NULL` trusted while `PyErr_Occurred()`) | #154385, #153800, #152682; #151968 (O2), #151126 (missing `PyErr_NoMemory`) | own scanners (widen tables + light error-state model) |
+| **1.8** | **Strengthen `scan_refcounts.py` borrowed-across-call set** (crown jewel) | Borrowed ref used across a call that can free it | Widen the "call that can run Python" list to include converter callbacks (`PyUnicode_FSConverter`, `PyObject_GetIter`), `PyObject_Repr`/`Str`, warnings, and state mutators (`setcontext`-style); flag borrowed loads from **slots**, not just `*_GET_ITEM` macros | #148382 (`_decimal CURRENT_CONTEXT`), #151403 (`_posixsubprocess __fspath__`), #154527 (FT variant) | own scanner (this is the family's crown-jewel shape) |
+
+Cheapest first wins in this tier: **1.1 (recursion-guard)** and **1.4 (pyerr-clear-in-dealloc)** —
+both have a ready sibling implementation to port, crisp signals, near-zero-FP, and ≥2 live 2026
+tracker exemplars usable directly as regression fixtures. **1.2 (FT races)** is the highest-yield
+but gated on the chassis decision (§5).
+
+---
+
+## 4. Tier 2 — Loop-closing workflow machinery
+
+These are chassis-light and wire straight into the fuzzing findings repos. Highest value/cost
+ratio in the whole plan.
+
+### 2.1 Informed-explore loop
+Port `rust-ext-review-toolkit/.../scripts/build_informed_briefing.py` + `commands/informed-explore.md`.
+The generator emits a Markdown briefing from three catalogs:
+- **`data/cpython_bug_shapes.json`** — reusable bug *shapes* (not file:line), each with a
+  `guarded_twin` (the correct sibling = the fix), a `hunt` directive (search siblings), severity,
+  `confirmed_examples`, and a `differential`. Seed from the classes in Tier 1 (borrowed-across-call,
+  return-NULL-no-exc, PyErr_Clear-in-dealloc, unguarded recursion, uninit-dealloc, alloc-overflow).
+- **`data/cpython_non_bugs.md`** — the FP taxonomy (e.g. `PyErr_Clear` after `PyDict_GetItem`-with-
+  sentinel is idiomatic; a borrowed ref held under a known-live owner is fine). The toolkit currently
+  has **zero** codified FP suppression — worth adding even if nothing else here lands.
+- **`--catalog-dir`** → reads `reports/*/meta.json` from `cpython-oom-findings` / `cpython-tsan-findings`.
+
+Every agent then gets three rules: confirm-don't-relitigate known findings, skip-or-justify known-FP
+classes, and hunt siblings via the guarded twin. Per-*module* memory (`Modules/_io/.cpython-review/
+findings.json`) fits CPython's directory-scoped review cadence.
+
+### 2.2 known-issues regression command
+Port `rustpy-review-toolkit/.../scripts/check_known_issues.py` + `commands/known-issues.md`.
+Build **`data/cpython_known_bugs.tsv`** (`bug_id \t Modules/foo.c:line \t category`) seeded from the
+oom/tsan findings repos + notable fixed segfaults. A fresh run of the category-matching scanner
+(`scan_null_checks` for a NULL catalog, `scan_refcounts` for a refcount catalog) classifies each site
+`present` / `line_drifted` / `absent` / `file_missing`, drift-tolerant. This is the natural home for
+the **version differential**: run at a CPython tag and answer "which catalogued crashes are still
+present / regressed after a revert."
+
+### 2.3 Reproducer / dynamic-verification harness
+Formalize `cext-review-toolkit/docs/reproducer-techniques.md` (+ `libfiu_helpers.py`,
+`mallocfault_harness.py`) — the doc that **already found a CPython-own bug** (`_PyFrame_GetLocals`
+NULL deref, `frameobject.c`, gh-146092, fixed upstream). Core engine: `_testcapi.set_nomemory(n,0)`
+dense-sweep OOM injection with subprocess-per-iteration isolation and exit-code semantics
+(139=SIGSEGV, 134=SIGABRT, 1=clean MemoryError). For CPython the target *is* the binary — run against
+a locally-built **debug/ASan CPython** (no install step). Add a thin `reproduce` command wrapping the
+dense-sweep harness. This upgrades a known-issues `present` verdict and a new candidate from *static
+match* to *reproduced crash*.
+
+### 2.4 Findings-repo feedback loop
+Adopt the family's `analyze → reproduce → record → regenerate` loop. **Decision needed (§5):** either
+feed the existing `cpython-oom-findings` / `cpython-tsan-findings` repos, or stand up a new
+`cpython-review-findings` (prefix e.g. `CPY-`) as the static-first counterpart (mirrors
+`rust-ext-review-findings` / `cext-review-findings`). Recording keeps `found_by` (which agent surfaced
+it), `guarded_twin`, and `cpython_behavior` (the differential). `gen_known_*` scripts regenerate the
+Tier-2.2 TSV, closing the loop back into the toolkit.
+
+---
+
+## 5. Tier 3 — Infrastructure to keep signal/noise usable
+
+### 3.1 THE CHASSIS DECISION (the architectural fork — needs your call)
+The FT/TSan detectors (1.2) and the STW-safety/lock-discipline ports need a **C call-graph
+primitive** (`extract_functions` + `find_calls_in_scope`) the toolkit does not have. Two paths:
+
+- **(A, recommended) Adopt cext/ft's `tree_sitter_utils.py` as a shared vendored chassis.** Larger
+  up-front cost, but it (i) unlocks the entire FT dimension, (ii) lets the existing regex scanners
+  gain precision (real function boundaries, real call detection — killing whole FP classes), and
+  (iii) removes the 8×-duplicated `find_cpython_root`. It also aligns this toolkit with the family's
+  vendoring model (sync forward from the shared root, never fork).
+- **(B) Write a regex call-graph analog.** Cheaper, lossier, and a permanent maintenance island.
+
+Recommendation: **A.** The FT seam is the single richest source of catalogued, mechanically-detectable
+bugs; a regex call-graph would cap its precision permanently. Note: `tsan-report-analyzer` (regex over
+TSan text) and `tsan-stress-generator` (a pure prompt) need **no** call graph and can ship ahead of
+this decision.
+
+### 3.2 A `data/` layer
+Create `data/` and extract the inlined prose tables into refreshable JSON: `deprecated_apis.json`,
+`refcount_api_semantics.json`, `fallible_apis.json`. Transfer **wholesale** from ft (they are already
+CPython-API vocabularies): `stw_safe_apis.json`, `lock_macros.json`, `critical_section_apis.json`,
+`atomic_patterns.json`, `thread_safe_apis.json`. Add `cpython_reachability_sources.json` (§3.3).
+
+### 3.3 Reachability-tiering (the S/N mechanism)
+CPython's candidate count is inherently huge; a flat dump is unusable. Adopt rustpy's tiering:
+- **T1** — directly Python-exposed C fns (entries in `PyMethodDef`/`PyGetSetDef`/`PyMemberDef`
+  arrays and `tp_*` slots): a bug here is directly reachable from a Python program.
+- **T2** — public `Py*`/`PyAPI_FUNC` C-API (reachable by extensions/embedders).
+- **T3** — `_Py*` / `static` internal helpers (transitive only, caller-guaranteed preconditions) →
+  **default-quieter.**
+
+Plus **input-provenance** signals (`data/cpython_reachability_sources.json`): a candidate whose
+triggering value flows from a parsed argument, a user `__index__`/`__hash__`/`__repr__`, or a
+user-supplied index/length is a *reachable* bug; one gated by an internal invariant (`assert`,
+"cannot fail") is weak and down-ranked. The preflight mapper stamps the tier; the safety agents rank
+by it.
+
+### 3.4 Preflight upgrade + history-context split
+- **`cpython-source-mapper`** (NEW preflight agent): classify each file hand-written vs
+  **Argument-Clinic-generated** (`Modules/clinic/*.h` markers), emit ACCEPTABLE-noise grep patterns
+  (Clinic boilerplate, `Py_RETURN_NONE`), and catalog init-style / GC types up front. The current
+  `include-graph-mapper` is *structural* only — this adds *triage* orientation. Every claim must be a
+  grep regex or a script finding-ID, not prose.
+- **Split history into two agents** (the code-review-toolkit shape): a new **`git-history-context`**
+  preflight that runs *early* (per-file `Modules/`/`Objects/`/`Python/` bug-fix-density watchlist to
+  prioritize the safety agents) — `pyo3-history-context` is a near-drop-in template — while keeping the
+  existing `git-history-analyzer` as the Group-E fix-completeness pass.
+- Add **shallow-clone detection** to discovery (CPython has decades of history; a `--depth` clone
+  silently truncates every temporal signal — the rust toolkits already guard this).
+
+### 3.5 C-vs-pure-Python parity agent (built-in oracle, novel, low effort)
+CPython *ships* dual implementations: `_decimal`/`_pydecimal`, `_io`/`_pyio`, `_json`, `_heapq`/`heapq`,
+`_datetime`/`datetime`, `_asyncio`/`asyncio`, `_statistics`, `_collections`, `_functools`. The pure-Python
+twin is a free differential oracle. A `cpython-parity-checker` agent (port cext's `parity-checker`
+prompt) finds behavioral divergences — a genuinely new capability, mostly a prompt. Pairs with 2.3:
+when a C candidate diverges from its twin (twin raises, C segfaults) the bug is confirmed and localized.
+
+---
+
+## 6. Tier 4 — Housekeeping (do first; cheap, unblocks trust)
+
+- **Fix CHANGELOG versioning.** It has only a flat `[Unreleased]` despite manifests at 0.4.0 and git
+  bumps for 0.2.0/0.3.0/0.4.0. Add dated `## [0.4.0]`/`[0.3.0]`/`[0.2.0]` sections; adopt git tags.
+- **Fix doc drift:** manifests/READMEs advertise "10 agents / 7 scripts"; the tree has **11 / 8**
+  (`git-history-analyzer` + `analyze_history.py` shipped under `[Unreleased]` uncounted).
+- **Establish a design doc.** Every other family member has an authoritative spec; this one's design
+  lives only in two READMEs. A short `cpython-review-toolkit-design.md` (agent roster, classification,
+  reachability tiers, the informed/known-issues grammar) would anchor future work — this file can seed it.
+- **Add tests for the 3 script-less agents** once 1.4/1.5/1.6 give them scripts.
+
+---
+
+## 7. Recommended sequencing
+
+**v0.5 — chassis-light wins + first flagship detectors** (no tree-sitter dependency):
+- Tier 4 housekeeping (CHANGELOG, counts, design doc).
+- 3.2 `data/` bootstrap + 3.3 reachability data + `cpython_non_bugs.md`.
+- 2.1 informed-explore + 2.2 known-issues (wired to oom/tsan findings repos).
+- 1.1 recursion-guard + 1.4 pyerr-clear-in-dealloc + 1.3 uninit-dealloc (all portable, near-zero-FP,
+  live regression fixtures ready).
+- 3.4 history-context split + shallow-clone detection.
+
+**v0.6 — the free-threading dimension** (gated on the §5 chassis decision):
+- 3.1 adopt tree-sitter-C chassis.
+- 1.2 `scan_ft_races.py` (T3→T2→T1) + STW-safety / lock-discipline / atomic-candidate ports from ft.
+- `tsan-report-analyzer` + `tsan-stress-generator` (can land at the *start* of v0.6 — no call graph).
+- Precision re-baseline of existing scanners now that real function boundaries exist.
+
+**v0.7 — dynamic loop + remaining detectors:**
+- 2.3 reproducer harness + `reproduce` command + 2.4 findings-repo loop.
+- 3.5 parity agent. 1.5 init-bypass. 1.6 memory-pattern promotion. 1.7/1.8 error-path/borrowed-ref
+  strengthening.
+- 3.1 `cpython-source-mapper` preflight (Argument-Clinic classification).
+
+---
+
+## 8. Decisions needed from you
+
+1. **Chassis (§3.1):** adopt the shared tree-sitter-C chassis (recommended — unlocks FT + upgrades
+   existing scanners), or stay regex + write a call-graph analog? This gates all FT work.
+2. **Findings repo (§2.4):** new `cpython-review-findings` (`CPY-`, static-first counterpart), or feed
+   the existing `cpython-oom-findings` / `cpython-tsan-findings`?
+3. **FT scope:** is reviewing CPython's *own* free-threaded C code in-scope here, or deferred to
+   `ft-review-toolkit`? (Argument for in-scope: the ft toolkit was literally calibrated against
+   CPython's own code — `scan_stw_safety.py` cites `Python/gc_free_threading.c` as ground truth — and
+   the tsan findings repo is CPython-specific.)
+4. **Scope of v0.5:** land the whole chassis-light bundle above, or start with the two flagship
+   detectors (1.1 + 1.4) + informed/known-issues as a smaller first cut?
+```
+```
+
+---
+
+### Appendix — evidence sources
+- Current-state inventory: `plugins/cpython-review-toolkit/{agents,scripts,commands}`, manifests, CHANGELOG, `docs/python-wrapper-new-without-init.md`, `reports/`.
+- Fuzzing catalogs: `~/projects/cpython-oom-findings` (schema + `ingest.py`/`gen_known_sites.py`; OOM classes O1–O7), `~/projects/cpython-tsan-findings` (races T1–T7), `~/projects/rustpython-findings` (mirror classes R1–R7).
+- Tracker (gh, authenticated, 2026-07-24): shapes A–I; umbrellas #151763/#153852/#146102.
+- Sibling ports: `rust-ext-review-toolkit/.../build_informed_briefing.py`+`informed-explore.md`; `rustpy-review-toolkit/.../check_known_issues.py`+`known-issues.md`+`known_panics.tsv`+`rustpython_reachability_sources.json`; `cext-review-toolkit/docs/reproducer-techniques.md`(+helpers)+`parity-checker.md`+`pyerr-clear-auditor.md`; `ft-review-toolkit/.../scan_stw_safety.py`+six `data/*.json`+`{stw-safety-checker,tsan-stress-generator,tsan-report-analyzer}.md`; this repo's own `pyo3-history-context` template (in the pyo3 sibling).

--- a/plugins/cpython-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cpython-review-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cpython-review-toolkit",
-  "version": "0.4.0",
-  "description": "CPython C code exploration and analysis agents: refcount auditing, error path analysis, GIL discipline checking, C complexity measurement, include graph mapping, PEP 7 style checking, NULL safety scanning, API deprecation tracking, macro hygiene review, and memory pattern analysis",
+  "version": "0.5.0",
+  "description": "CPython C code exploration and analysis agents: refcount auditing, error path analysis, GIL discipline, C complexity, include-graph mapping, PEP 7 style, NULL safety, deprecation, macros, and memory patterns — plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command",
   "author": {
     "name": "Danzin"
   }

--- a/plugins/cpython-review-toolkit/README.md
+++ b/plugins/cpython-review-toolkit/README.md
@@ -48,7 +48,7 @@ claude --plugin-dir cpython-review-toolkit/plugins/cpython-review-toolkit
 
 - **Claude Code** installed and running.
 - **Python 3.10+** for the analysis scripts (type union syntax, match statements).
-- No third-party Python packages — all scripts use only the standard library.
+- **tree-sitter + tree-sitter-c** (`pip install tree-sitter tree-sitter-c`) — required by the tree-sitter-based crash-class detectors (`recursion-guard`, `pyerr-clear`, `uninit-dealloc`), the `known-issues` command, and the `informed-explore` briefing. The legacy regex scanners (refcounts, error-paths, null-safety, GIL, complexity, PEP 7, includes) remain stdlib-only.
 
 ## Commands
 
@@ -57,7 +57,7 @@ claude --plugin-dir cpython-review-toolkit/plugins/cpython-review-toolkit
 The primary command. Runs the include-graph-mapper first for structural context, then dispatches selected agents.
 
 ```bash
-# Full exploration (all 10 agents)
+# Full exploration (all agents)
 /cpython-review-toolkit:explore
 
 # Specific directory
@@ -70,7 +70,7 @@ The primary command. Runs the include-graph-mapper first for structural context,
 /cpython-review-toolkit:explore . all summary
 ```
 
-**Aspects**: `includes`, `refcounts`, `errors`, `gil`, `complexity`, `style`, `null-safety`, `deprecation`, `macros`, `memory`, `all`
+**Aspects**: `includes`, `refcounts`, `errors`, `gil`, `complexity`, `style`, `null-safety`, `deprecation`, `macros`, `memory`, `recursion`, `pyerr-clear`, `uninit-dealloc`, `history`, `all`
 
 **Options**: `deep` (full detail), `summary` (top-level only), `parallel` (concurrent agents)
 
@@ -101,6 +101,23 @@ Quick health dashboard — all agents in summary mode, producing a scored table 
 /cpython-review-toolkit:health Python/
 ```
 
+### `/cpython-review-toolkit:known-issues [scope]`
+
+Regression baseline. Cross-references `data/cpython_known_bugs.tsv` — a seed catalog of previously-found CPython crashes (from the fusil OOM/TSan findings repos and the tracker) — against a fresh scan, classifying each as `present` / `line_drifted` / `absent` / `file_missing` / `no_scanner`. Answers "which catalogued crashes are still here, and did any regress?" (Note: some crash shapes carry no scannable token, so `absent` is not proof of a fix.)
+
+```bash
+/cpython-review-toolkit:known-issues
+/cpython-review-toolkit:known-issues Objects/
+```
+
+### `/cpython-review-toolkit:informed-explore [scope]`
+
+A catalog-seeded targeted pass. Builds a briefing from `data/cpython_bug_shapes.json` (each bug shape + its guarded twin + hunt directive + differential) and the `data/cpython_non_bugs.md` FP taxonomy, then runs the explore agents with three rules: confirm-don't-relitigate known findings, skip (or justify) known FP classes, and hunt siblings via the guarded twin. Optionally `--catalog-dir` a `cpython-review-findings` repo.
+
+```bash
+/cpython-review-toolkit:informed-explore Objects/
+```
+
 ## Agents
 
 ### Safety-Critical (script-backed)
@@ -113,6 +130,16 @@ These agents find bugs that cause crashes, memory corruption, or undefined behav
 | **error-path-analyzer** | Missing NULL checks after API calls, return NULL without PyErr_Set*, incomplete goto cleanup, inconsistent error conventions | `scan_error_paths.py` |
 | **null-safety-scanner** | Unchecked malloc/PyMem_Malloc, dereference before NULL check, PyArg_Parse without return check | `scan_null_checks.py` |
 | **gil-discipline-checker** | Mismatched BEGIN/END_ALLOW_THREADS, Python API calls without GIL, blocking I/O with GIL held, PyGILState balance | `scan_gil_usage.py` |
+
+### Crash-Class Detectors (tree-sitter based)
+
+These target specific reachable-from-Python crash classes grounded in the fusil OOM/TSan findings and the CPython tracker. They parse a real C syntax tree and stay deliberately quiet — a whole-tree run surfaces a small, triageable set (each validated against confirmed CPython crashes).
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **recursion-guard-auditor** | Recursion-prone slots (`tp_hash`/`tp_richcompare`/`tp_repr`/`tp_str`, generic-alias parameter walks) that descend a user-controlled object graph without `Py_EnterRecursiveCall`/`Py_ReprEnter` → native-stack-overflow SIGSEGV (gh-154318, gh-154275) | `scan_recursion_guards.py` |
+| **pyerr-clear-auditor** | `PyErr_Clear()` in the destructor family (`tp_dealloc`/`tp_clear`/`tp_finalize`/`tp_traverse`) with no save/restore, swallowing an in-flight `MemoryError`/`KeyboardInterrupt` (gh-152083) | `scan_pyerr_clear.py` |
+| **uninitialized-dealloc-auditor** | Non-zeroing allocation freed on an error path before members are NULL-initialized → `tp_dealloc` reads garbage (gh-151815, gh-152851) | `scan_uninit_dealloc.py` |
 
 ### Code Quality (script-backed)
 
@@ -132,15 +159,22 @@ These agents search the codebase directly using Grep and read files for deep ana
 | **macro-hygiene-reviewer** | Missing parentheses in macros, multiple evaluation, multi-statement macros without do-while, naming |
 | **memory-pattern-analyzer** | Mismatched alloc/free families, sprintf without bounds, integer overflow in allocation sizes |
 
+### Temporal
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **git-history-context** | Preflight (runs early): per-file bug-fix-density watchlist + recurring fix-keyword clusters + shallow-clone guard, so the safety agents scrutinize the historically-buggiest files first | `analyze_history.py` |
+| **git-history-analyzer** | Post-hoc (runs last): fix-completeness review, similar-bug detection, churn-risk matrix, Argument-Clinic / API-modernization migration gaps | `analyze_history.py` |
+
 ## How It Works
 
 ### Scripts Find Candidates, Agents Confirm
 
-The 7 analysis scripts use regex-based scanning — not a C parser — to identify candidate issues. This is a deliberate design choice:
+The analysis scripts identify candidate issues; the agent then reads the real code and classifies each finding. Two generations of scanner coexist:
 
-1. **Stdlib-only**: No pycparser, tree-sitter, or libclang dependency.
-2. **CPython's regularity**: PEP 7 makes function definitions, brace placement, and naming conventions predictable enough for regex.
-3. **Acceptable false positive rate**: Scripts report candidates (expect 30-50% false positives). The agent reads the actual code, tracks control flow, and classifies each finding as confirmed, likely, or false positive.
+1. **Legacy regex scanners** (refcounts, error-paths, null-safety, GIL, complexity, PEP 7, includes) are stdlib-only. PEP 7's regularity makes function definitions, brace placement, and naming predictable enough for regex.
+2. **Tree-sitter crash-class detectors** (`recursion-guard`, `pyerr-clear`, `uninit-dealloc`) parse a real C syntax tree via the shared `tree_sitter_utils` chassis (vendored from the cext sibling), so they track true function boundaries, calls, and slot tables instead of line patterns.
+3. **Acceptable false positive rate**: Scripts report candidates (expect 10-50% false positives depending on the detector). The agent reads the actual code, tracks control flow, and classifies each finding as FIX / CONSIDER / POLICY / ACCEPTABLE.
 
 ### CPython Layout Awareness
 
@@ -210,16 +244,19 @@ The `explore` command runs agents in a structured pipeline:
 | Phase | Agents | Purpose |
 |-------|--------|---------|
 | **0** | Project discovery | Detect CPython layout, count files, identify version |
-| **1** | include-graph-mapper | Structural context for all other agents |
+| **1** | include-graph-mapper, git-history-context | Structural + temporal context for all other agents |
 | **2A** | refcount-auditor, error-path-analyzer | Safety-critical (highest value) |
+| **2A2** | recursion-guard-auditor, pyerr-clear-auditor, uninitialized-dealloc-auditor | Crash-class detectors (tree-sitter) |
 | **2B** | null-safety-scanner, gil-discipline-checker | Memory safety |
 | **2C** | c-complexity-analyzer, pep7-style-checker | Code quality |
 | **2D** | api-deprecation-tracker, macro-hygiene-reviewer, memory-pattern-analyzer | Maintenance |
+| **2E** | git-history-analyzer | Temporal fix-completeness (runs last) |
 | **3** | Synthesis | Deduplicate, resolve conflicts, produce summary |
 
 ## Limitations
 
-- **Regex-based, not a real C parser**: Cannot track through pointer aliasing, complex control flow, or macros that generate code. Reports candidates, not definitive bugs.
+- **Mixed parsing**: the legacy scanners are regex-based (cannot track pointer aliasing, complex control flow, or code-generating macros); the crash-class detectors use tree-sitter but are still syntactic — they report candidates, not definitive bugs, and the agent triage step is where FIX-confidence is earned.
+- **No dynamic reproduction yet**: the toolkit is static. Confirming a candidate crash (e.g. via `_testcapi.set_nomemory` OOM injection on a debug/ASan build) is a manual step today; an automated reproducer harness is planned (see `docs/improvement-plan.md`).
 - **No clang-tidy/cppcheck integration yet**: A future phase could integrate external C analysis tools alongside the CPython-specific scripts.
 - **Single-file scope for scripts**: Scripts analyze each function independently. Cross-function reference ownership transfer is tracked only at the API boundary level, not through arbitrary call chains.
 - **Best on idiomatic CPython code**: The regex patterns are tuned for PEP 7 style. Non-standard C code (vendored libraries, generated code) may produce more false positives.
@@ -234,27 +271,47 @@ cpython-review-toolkit/
 ├── agents/
 │   ├── refcount-auditor.md
 │   ├── error-path-analyzer.md
-│   ├── gil-discipline-checker.md
-│   ├── c-complexity-analyzer.md
-│   ├── include-graph-mapper.md
-│   ├── pep7-style-checker.md
 │   ├── null-safety-scanner.md
+│   ├── gil-discipline-checker.md
+│   ├── recursion-guard-auditor.md          # crash-class (tree-sitter)
+│   ├── pyerr-clear-auditor.md              # crash-class (tree-sitter)
+│   ├── uninitialized-dealloc-auditor.md    # crash-class (tree-sitter)
+│   ├── c-complexity-analyzer.md
+│   ├── pep7-style-checker.md
+│   ├── include-graph-mapper.md
 │   ├── api-deprecation-tracker.md
 │   ├── macro-hygiene-reviewer.md
-│   └── memory-pattern-analyzer.md
+│   ├── memory-pattern-analyzer.md
+│   ├── git-history-context.md              # preflight temporal
+│   └── git-history-analyzer.md             # post-hoc temporal
 ├── commands/
 │   ├── explore.md
+│   ├── informed-explore.md
+│   ├── known-issues.md
 │   ├── health.md
 │   ├── hotspots.md
 │   └── map.md
+├── data/
+│   ├── cpython_known_bugs.tsv              # known-issues regression catalog
+│   ├── cpython_bug_shapes.json             # informed-explore bug shapes
+│   ├── cpython_reachability_sources.json   # T1/T2/T3 reachability tiers
+│   └── cpython_non_bugs.md                 # false-positive taxonomy
 └── scripts/
+    ├── tree_sitter_utils.py                # vendored C parsing chassis
+    ├── scan_common.py                      # shared helpers
     ├── analyze_includes.py
+    ├── analyze_history.py
     ├── check_pep7.py
     ├── measure_c_complexity.py
     ├── scan_error_paths.py
     ├── scan_gil_usage.py
     ├── scan_null_checks.py
-    └── scan_refcounts.py
+    ├── scan_refcounts.py
+    ├── scan_recursion_guards.py            # tree-sitter detector
+    ├── scan_pyerr_clear.py                 # tree-sitter detector
+    ├── scan_uninit_dealloc.py              # tree-sitter detector
+    ├── check_known_issues.py               # known-issues command
+    └── build_informed_briefing.py          # informed-explore briefing
 ```
 
 ## Comparison with code-review-toolkit
@@ -262,12 +319,12 @@ cpython-review-toolkit/
 | Dimension | code-review-toolkit | cpython-review-toolkit |
 |-----------|--------------------|-----------------------|
 | **Language** | Python | C (CPython source) |
-| **Parsing** | Python `ast` module | Regex-based |
+| **Parsing** | Python `ast` module | Regex (legacy scanners) + tree-sitter (crash-class detectors) |
 | **Root detection** | `pyproject.toml`, `.git` | `Include/Python.h`, `Objects/object.c` |
-| **Top bug class** | Logic errors, dead code | Refcount leaks, NULL deref, GIL violations |
+| **Top bug class** | Logic errors, dead code | Refcount leaks, NULL deref, native-stack-overflow SIGSEGV, GIL violations |
 | **Style guide** | PEP 8 | PEP 7 |
-| **Agents** | 14 | 10 |
-| **Scripts** | 8 | 7 |
+| **Agents** | 14 | 15 |
+| **Scripts** | 8 | 15 |
 
 ## Author
 

--- a/plugins/cpython-review-toolkit/agents/git-history-context.md
+++ b/plugins/cpython-review-toolkit/agents/git-history-context.md
@@ -1,0 +1,68 @@
+---
+name: git-history-context
+description: Preflight temporal-orientation agent — runs EARLY (right after include-graph-mapper, before the safety-critical agents) to give them a per-file priority signal. Produces a bug-fix-density watchlist over Modules/ Objects/ Python/, recurring fix-keyword clusters, and a shallow-clone warning. Distinct from git-history-analyzer, which runs LAST and does fix-completeness cross-reference. Uses analyze_history.py.\n\n<example>\nContext: Starting a full review and wanting to prioritize the buggiest files first.\nuser: "Where has CPython been fixing the most crashes lately?"\nassistant: "I'll run git-history-context to build a per-file bug-fix-density watchlist so the safety agents look at the hottest files first."\n<commentary>\nThis is the early, priority-seeding history pass — not the post-hoc fix-completeness analyzer.\n</commentary>\n</example>
+model: opus
+color: cyan
+---
+
+You are a temporal-orientation agent. You run **early** in the explore pipeline (after the structural include-graph-mapper, before the safety-critical agents) so downstream agents can spend their attention on the historically-buggiest code first. You are the counterpart to `git-history-analyzer`, which runs **last** to cross-reference the other agents' findings against history — do not duplicate its fix-completeness work.
+
+## Step 0: Shallow-clone guard (do this first)
+
+CPython has decades of history. A shallow clone silently truncates every temporal signal, making this agent's output misleading. Check:
+
+```bash
+git -C <scope> rev-parse --is-shallow-repository
+```
+
+If it prints `true`, STOP and report prominently: *"This is a shallow clone — history analysis is truncated and unreliable. Run `git fetch --unshallow` for meaningful results."* Then produce only a caveated, best-effort summary.
+
+## Scope
+
+The CPython checkout under review. Focus the watchlist on `Modules/`, `Objects/`, and `Python/` (the crash-bearing C).
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/analyze_history.py <scope>
+```
+
+Use its commit classification, per-file/per-function churn, keyword clustering, and co-change output. For a long window, pass a generous `--max-commits` so a `--days`-style window isn't silently truncated.
+
+## What to produce
+
+### 1. Per-file bug-fix-density watchlist
+Rank the C files by density of **crash/safety** fix commits (keywords: `crash`, `segfault`, `use-after-free`, `refleak`, `double free`, `NULL`, `overflow`, `race`, `data race`, `deadlock`, `assertion`, `UAF`). Output the top ~20 as a table: file | crash-fix commits | recent example (hash + subject). This is the priority signal the safety agents consume.
+
+### 2. Recurring fix-keyword clusters
+Group the fix history into recurring themes (e.g. "OOM NULL-deref", "iterator concurrency race", "recursion guard", "refcount on error path") with commit counts and a year-by-year histogram. A cluster that is still active is where the next bug of that class likely hides.
+
+### 3. Hand-off hints for downstream agents
+For each hot file, name which safety agent should look hardest (refcount-auditor / recursion-guard-auditor / pyerr-clear-auditor / null-safety-scanner / etc.) based on the dominant fix theme in its history.
+
+## Output Format
+
+```markdown
+## Git History Context (preflight)
+
+### Clone health
+- Shallow clone: yes/no  [+ unshallow warning if yes]
+- Commits analyzed: N  | window: ...
+
+### Bug-fix-density watchlist (top 20)
+| File | Crash-fix commits | Recent example | Suggested agent |
+|------|-------------------|----------------|-----------------|
+| Modules/_io/textio.c | 14 | abc1234 fix seek cookie OOB | null-safety, recursion-guard |
+
+### Recurring fix clusters
+- **OOM NULL-deref** — N commits (2024: .., 2025: .., 2026: ..); still active. → null-safety-scanner, error-path-analyzer.
+- ...
+
+### Priority hand-off
+[Ranked list of files × the agent that should scrutinize each first.]
+```
+
+## Important Guidelines
+- **You seed priority; you do not judge findings.** Keep output to orientation — the safety agents do the actual bug-finding.
+- **Recency matters more than raw churn.** A file with 3 crash fixes this year outranks one with 10 from a decade ago.
+- **Feed the watchlist forward.** The explore command injects this output into the safety-critical agents' prompts; write it so they can act on it directly.

--- a/plugins/cpython-review-toolkit/agents/pyerr-clear-auditor.md
+++ b/plugins/cpython-review-toolkit/agents/pyerr-clear-auditor.md
@@ -1,0 +1,70 @@
+---
+name: pyerr-clear-auditor
+description: Use this agent to find exception-clobbering PyErr_Clear() calls in CPython's destructor family — tp_dealloc / tp_clear / tp_finalize / tp_traverse — where an unguarded clear silently swallows an in-flight MemoryError / KeyboardInterrupt / SystemExit. Uses scan_pyerr_clear.py.\n\n<example>\nContext: The user wants to find destructors that eat live exceptions.\nuser: "Does anything clear a pending exception during teardown?"\nassistant: "I'll use the pyerr-clear-auditor to find PyErr_Clear() in dealloc/clear/finalize with no save/restore guard."\n<commentary>\ncontext_tp_dealloc (gh-152083), subtype_dealloc, and deque_clear are confirmed instances of this class.\n</commentary>\n</example>
+model: opus
+color: orange
+---
+
+You are an expert in CPython exception-state discipline, specializing in the destructor family. Your mission is to find `PyErr_Clear()` calls that clobber an exception that is already in flight.
+
+## Why this matters
+
+Destructors and finalizers run at arbitrary points — commonly while an exception is *already being handled* (an object's last reference is dropped mid-unwind). A `PyErr_Clear()` there, with no save/restore of the pending exception, silently swallows the caller's live `MemoryError` / `KeyboardInterrupt` / `SystemExit`, turning a real error into a mysterious success or hang. Confirmed instances: `context_tp_dealloc` (gh-152083), `subtype_dealloc`, `deque_clear` (Modules/_collectionsmodule.c).
+
+The correct idiom brackets the risky work with a save/restore pair — `PyErr_GetRaisedException()` / `PyErr_SetRaisedException()` (or the older `PyErr_Fetch` / `PyErr_Restore`) — or reports the secondary error via `PyErr_WriteUnraisable()`.
+
+## Scope
+
+Analyze the scope provided. Default: the entire project. Requires tree-sitter (`pip install tree-sitter tree-sitter-c`).
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/scan_pyerr_clear.py [scope]
+```
+
+The scanner is **scoped to the destructor family only** — a function is in scope if its name ends in `_dealloc`/`_finalize`/`_clear`/`_traverse`, or it is wired to `tp_dealloc`/`tp_finalize`/`tp_clear`/`tp_traverse` in a static type table. It suppresses functions that already use a save/restore API anywhere in the body.
+
+Key fields:
+- `findings[].slot`: which destructor slot (`tp_dealloc` / `tp_finalize` / `tp_clear` / `tp_traverse`).
+- `findings[].confidence`: `high` (dealloc/finalize/clear) or `medium` (traverse — a clear there is unusual anyway).
+
+## Analysis Strategy
+
+### Phase 1: Confirm an exception can actually be live
+For each finding, ask whether this destructor path can run while an exception is pending:
+- **tp_finalize / tp_dealloc / tp_clear**: yes in general — GC and refcount drops happen during exception handling. FIX unless the specific clear is provably unreachable with a live exception.
+- Check whether the `PyErr_Clear()` is *deliberately* clearing an error this function itself just raised on a best-effort cleanup call — if so, it should still save/restore the *outer* exception.
+
+### Phase 2: Read past the whole-function suppression
+The scanner suppresses a function if *any* save/restore API appears in it. In a large destructor (e.g. `subtype_dealloc`), a save/restore may guard one region while a **different** `PyErr_Clear()` remains exposed — the scanner will miss that. When reviewing a big teardown function that the scanner cleared, spot-check each `PyErr_Clear()` individually.
+
+### Phase 3: Prescribe the fix
+The fix is almost always: capture at the top with `PyObject *exc = PyErr_GetRaisedException();`, do the teardown, then `PyErr_SetRaisedException(exc);` — or replace the bare clear with `PyErr_WriteUnraisable(self)` if the secondary error should be surfaced.
+
+## Output Format
+
+```markdown
+## PyErr_Clear Destructor Analysis Results
+
+### Summary
+- Destructor-family functions scanned: N
+- FIX (unguarded clear in dealloc/finalize/clear): N
+- CONSIDER (traverse / uncertain reachability): N
+
+### Findings
+
+#### [FIX] deque_clear swallows a pending exception (Modules/_collectionsmodule.c:LINE)
+**What**: `PyErr_Clear()` on the `newblock`-allocation-failure path with no save/restore.
+**Impact**: an in-flight MemoryError is silently discarded during teardown.
+**Fix**: bracket with `PyErr_GetRaisedException()` / `PyErr_SetRaisedException()`.
+```
+
+## Classification Guide
+- **FIX**: unguarded `PyErr_Clear()` in `tp_dealloc` / `tp_finalize` / `tp_clear` on a path reachable with a live exception (the default assumption for teardown).
+- **CONSIDER**: `tp_traverse` clears (traverse should be side-effect-free — investigate why a clear is there at all); or a case where you cannot establish that an exception is ever live on this path.
+- **ACCEPTABLE**: the clear is provably only reached with no pending exception (rare; document the reasoning).
+
+## Important Guidelines
+- **`PyErr_WriteUnraisable` / save-restore in the same function ⇒ intentional.** The scanner already treats these as guards; if you see one near a flagged clear that the scanner missed, it's likely fine.
+- **This is the O3 class from the OOM findings** (cpython-oom-findings). Cross-reference confirmed IDs and hunt siblings across the same module family.

--- a/plugins/cpython-review-toolkit/agents/recursion-guard-auditor.md
+++ b/plugins/cpython-review-toolkit/agents/recursion-guard-auditor.md
@@ -1,0 +1,71 @@
+---
+name: recursion-guard-auditor
+description: Use this agent to find recursion-prone type slots in CPython C source that lack a recursion guard — a deeply-nested or cyclic object overflows the native C stack (SIGSEGV) instead of raising RecursionError. Covers tp_hash / tp_richcompare / tp_repr / tp_str and the generic-alias parameter walk. Uses scan_recursion_guards.py.\n\n<example>\nContext: The user wants to find native-stack-overflow crashes reachable from Python.\nuser: "Can a deeply nested tuple crash the interpreter through hashing?"\nassistant: "I'll use the recursion-guard-auditor to find recursion-prone slots that descend the object graph without Py_EnterRecursiveCall."\n<commentary>\ntuple_hash / frozendict_hash and _Py_make_parameters are confirmed instances of this class (gh-154318, gh-154275).\n</commentary>\n</example>
+model: opus
+color: red
+---
+
+You are an expert in CPython's C runtime, specializing in native-stack-overflow crashes reachable from pure Python. Your mission is to find recursion-prone type slots that descend a user-controlled object graph without a recursion guard.
+
+## Why this matters
+
+CPython converts Python-level runaway recursion into a catchable `RecursionError` via `Py_EnterRecursiveCall()` (and `Py_ReprEnter()` for repr/str). A recursive C slot that omits the guard bypasses that protection: a deeply-nested or reference-cyclic object drives the **C stack** to overflow, which is an **uncatchable SIGSEGV**, not a `RecursionError`. This is a confirmed, recurring, copy-paste-propagated class: `tuple_hash` / `frozendict_hash` (gh-154318) and `_Py_make_parameters` (gh-154275).
+
+## Scope
+
+Analyze the scope provided. Default: the entire project. Requires tree-sitter (`pip install tree-sitter tree-sitter-c`).
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/scan_recursion_guards.py [scope]
+```
+
+Key fields:
+- `findings[].shape`: `self_recursion` (the function calls itself) or `container_element_descent` (loops over a container calling `PyObject_Hash`/`Repr`/`RichCompare` on items).
+- `findings[].slot`: `tp_hash` / `tp_richcompare` / `tp_repr` / `tp_str` / `parameter_walk`.
+- `findings[].confidence`: `high` (self-recursion, or hash/richcompare container descent) or `medium` (repr/str descent — often carries other bounds).
+
+## Analysis Strategy
+
+### Phase 1: Triage by nestability
+The decisive question for each finding is **can the receiving type actually be nested deeply or cyclically from Python?**
+- **Unbounded → FIX**: containers and container-like types whose elements can themselves be the same/other containers — `tuple`, `frozenset`, `dict` keys, `list`, `GenericAlias`/`Union` parameter walks. A user can build `x = []; x.append(x)` or a million-deep nesting.
+- **Bounded → ACCEPTABLE**: a type that cannot recurse into itself (e.g. a code object's fields, a fixed-arity record whose elements are never the same container). Confirm the element type can't reach back to this slot.
+
+### Phase 2: Confirm the guard is truly absent
+The scanner suppresses a finding only if a guard macro appears **anywhere** in the function body. Two caveats to check by reading:
+- A large function (e.g. `subtype_dealloc`-style) may guard one path but leave the flagged descent unguarded — the scanner's whole-function suppression can hide that. (Inverse can also happen: a guard present for an unrelated reason.)
+- A guard on a *caller* (the dispatch wrapper `PyObject_Repr`/`PyObject_Hash` already wrap `Py_EnterRecursiveCall`) can make a leaf slot safe. Verify whether this slot is only ever reached through a guarded dispatcher, or also directly.
+
+### Phase 3: Differential confirmation (optional, high-value)
+Reproduce on a locally-built debug CPython: construct a deeply-nested or self-referential instance and trigger the slot (`hash(x)`, `repr(x)`, `x == y`, `list[x]`). A SIGSEGV (not `RecursionError`) confirms it. Record confirmed crashes in the findings repo. Note: a matching crash in the *released* CPython is still a bug — a native stack overflow is never acceptable behavior.
+
+## Output Format
+
+```markdown
+## Recursion-Guard Analysis Results
+
+### Summary
+- Recursion-prone slots scanned: N
+- FIX (unbounded, unguarded): N
+- CONSIDER / ACCEPTABLE: N
+
+### Findings
+
+#### [FIX] tuple_hash descends elements without a recursion guard (Objects/tupleobject.c:LINE)
+**What**: `tuple_hash` loops over items calling `PyObject_Hash` with no `Py_EnterRecursiveCall`.
+**Reachability**: `hash(deeply_nested_tuple)` — tuples nest arbitrarily.
+**Impact**: native C-stack overflow → SIGSEGV, not a catchable RecursionError.
+**Fix**: bracket the descent with `Py_EnterRecursiveCall(" while hashing a tuple")` / `Py_LeaveRecursiveCall()`.
+```
+
+## Classification Guide
+- **FIX**: unguarded recursion in a slot on a type the user can nest deeply or cyclically (containers, generic-alias parameter walks, self-recursive descents). Cross-reference the CPython tracker — `tuple_hash`/`frozendict_hash` = gh-154318, `_Py_make_parameters` = gh-154275.
+- **CONSIDER**: `tp_repr`/`tp_str` descents where an alternate bound may exist, or a type whose maximum nesting depth is plausibly small but not provably bounded.
+- **ACCEPTABLE**: the receiving element type provably cannot reach this slot again (no possible deep/cyclic nesting).
+
+## Important Guidelines
+- **The guarded twin is the fix.** Almost every buggy slot has a correctly-guarded sibling in the same file (a `*_repr` that calls `Py_ReprEnter`, a `*_hash` that calls `Py_EnterRecursiveCall`). Cite it as the fix pattern and hunt for other unguarded siblings.
+- **Copy-paste propagation.** gh-154318 explicitly notes the guardless algorithm was copied. When you confirm one, grep the tree for structurally identical slots (`union_hash`, other container hashes) — the scanner already surfaces several.
+- **This is syntactic.** The scanner cannot prove reachability through function pointers or macro dispatch; Phase 1/2 human triage is where FIX-confidence is earned.

--- a/plugins/cpython-review-toolkit/agents/uninitialized-dealloc-auditor.md
+++ b/plugins/cpython-review-toolkit/agents/uninitialized-dealloc-auditor.md
@@ -1,0 +1,66 @@
+---
+name: uninitialized-dealloc-auditor
+description: Use this agent to find constructors that free a half-built object on an error path — a non-zeroing allocator (PyObject_New / PyObject_GC_New) whose object is Py_DECREF'd before its members are NULL-initialized, so tp_dealloc/tp_clear reads uninitialized member pointers (a crash, dominant under OOM). Uses scan_uninit_dealloc.py.\n\n<example>\nContext: The user wants to find OOM-path crashes from half-constructed objects.\nuser: "Which constructors can crash in tp_dealloc when an allocation fails?"\nassistant: "I'll use the uninitialized-dealloc-auditor to find non-zeroing allocations freed before their members are initialized."\n<commentary>\ntemplate_iter (gh-151815) and blake2 .copy() (gh-152851) are confirmed instances of this class.\n</commentary>\n</example>
+model: opus
+color: yellow
+---
+
+You are an expert in CPython object construction and teardown. Your mission is to find constructors that can free a half-initialized object, so its `tp_dealloc` / `tp_clear` reads uninitialized (garbage) member pointers and crashes.
+
+## Why this matters
+
+`PyObject_New` / `PyObject_GC_New` / `PyObject_NewVar` allocate an object but **do not zero** its type-specific fields — those hold garbage until the constructor assigns them. A correct constructor NULL-initializes members (or `memset`s the object) *before* any fallible step. A buggy one performs a fallible call first and, on failure, `Py_DECREF`s the object — running `tp_dealloc`/`tp_clear`, which `Py_XDECREF`s member pointers that are still garbage. This is the dominant reachable-from-Python crash surface under out-of-memory. Confirmed: `template_iter` (gh-151815), blake2 `.copy()` with an uninitialized `impl` enum (gh-152851).
+
+## Scope
+
+Analyze the scope provided. Default: the entire project. Requires tree-sitter (`pip install tree-sitter tree-sitter-c`).
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/scan_uninit_dealloc.py [scope]
+```
+
+Findings are **medium-confidence candidates** (a within-constructor heuristic): a non-zeroing allocation whose object is freed on an error path with no member NULL-init (and no `memset`) before the free. Key fields: `findings[].allocator`, `findings[].variable`, `findings[].function`.
+
+## Analysis Strategy
+
+### Phase 1: Confirm the tp_dealloc/tp_clear reads the members
+Read the type's `tp_dealloc` (and `tp_clear`). The finding is real only if the destructor **reads a member the constructor had not yet initialized** at the point of the early free:
+- Does `tp_dealloc` do `Py_XDECREF(self->member)` / deref `self->member` / `switch` on an enum member?
+- Was that member still uninitialized when the early `Py_DECREF` ran? Walk the constructor from the allocation to the failing branch and list which members are set.
+- **ACCEPTABLE** if the destructor only touches members that are always set before any early free, or if `tp_alloc` (a zeroing allocator) is actually used.
+
+### Phase 2: Verify the allocator really doesn't zero
+`PyObject_GC_New` etc. do not zero. But confirm the object isn't zeroed by a wrapper or a following `memset` the scanner may have missed, and that construction doesn't go through `tp_alloc`/`PyType_GenericAlloc` (which zero).
+
+### Phase 3: Differential / OOM reproduction (high-value)
+Reproduce on a debug/ASan CPython using `_testcapi.set_nomemory(n, 0)` to fail the exact allocation on the error path, then trigger the constructor from Python. A crash in `tp_dealloc` confirms it. Record confirmed crashes in the findings repo (this is OOM class O5 / bug class B).
+
+## Output Format
+
+```markdown
+## Uninitialized-Dealloc Analysis Results
+
+### Summary
+- Candidate constructors: N
+- FIX (dealloc confirmed to read an uninitialized member): N
+- ACCEPTABLE (dealloc-safe / zeroing alloc): N
+
+### Findings
+
+#### [FIX] template_iter frees a half-built iterator (Objects/templateobject.c:LINE)
+**What**: `it = PyObject_GC_New(...)`; on `PyObject_GetIter` failure `Py_DECREF(it)` runs before `it->index`/other members are set.
+**Impact**: tp_dealloc reads uninitialized member → crash (esp. under OOM).
+**Fix**: NULL all members immediately after allocation, before the first fallible call.
+```
+
+## Classification Guide
+- **FIX**: the destructor demonstrably reads a member that is uninitialized at the early-free point. Cross-reference gh-151815 (template_iter), gh-152851 (blake2), and the OOM findings (class O5).
+- **CONSIDER**: plausible but you cannot fully trace which members are set before the free without running it — flag for OOM reproduction.
+- **ACCEPTABLE**: destructor is safe against the uninitialized state, or a zeroing allocator is used.
+
+## Important Guidelines
+- **Precision is deliberately traded for recall here** — this is the lowest-precision detector in the suite. Every finding needs the Phase-1 constructor↔destructor read before it can be called FIX.
+- **The fix is almost always "NULL members right after allocation."** Prefer that over restructuring the error paths.
+- **`Py_UNREACHABLE()`/`switch` on an uninitialized enum** (the blake2 shape) is a wild-free even on release builds — treat enum-discriminated payloads with extra suspicion.

--- a/plugins/cpython-review-toolkit/commands/explore.md
+++ b/plugins/cpython-review-toolkit/commands/explore.md
@@ -31,8 +31,14 @@ Parse arguments into three categories:
 - `deprecation` → api-deprecation-tracker
 - `macros` → macro-hygiene-reviewer
 - `memory` → memory-pattern-analyzer
+- `recursion` → recursion-guard-auditor
+- `pyerr-clear` → pyerr-clear-auditor
+- `uninit-dealloc` → uninitialized-dealloc-auditor
 - `history` → git-history-analyzer
 - `all` → all agents (default)
+
+Note: `recursion`, `pyerr-clear`, and `uninit-dealloc` are the tree-sitter-based
+crash-class detectors (require `pip install tree-sitter tree-sitter-c`).
 
 **Options**:
 - `deep` → full detail, no output truncation
@@ -55,10 +61,11 @@ Before launching any agents:
 
 Launch the foundational context provider with the specified scope:
 
-**Group 0 — Structural context (always runs first)**:
+**Group 0 — Structural + temporal context (always runs first)**:
 - **include-graph-mapper** — include dependencies, API tiers, coupling
+- **git-history-context** — per-file bug-fix-density watchlist + shallow-clone guard, so the safety agents scrutinize the historically-buggiest files first (distinct from git-history-analyzer, which runs last)
 
-Store output for injection into Phase 2 agents.
+Store both outputs for injection into Phase 2 agents.
 
 ### Phase 2: Targeted Analysis
 
@@ -69,6 +76,11 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 **Group A — Safety-critical analysis** (highest value):
 1. refcount-auditor
 2. error-path-analyzer
+
+**Group A2 — Crash-class detectors (tree-sitter based)**:
+- recursion-guard-auditor — native-stack-overflow SIGSEGV in recursion-prone slots (gh-154318, gh-154275)
+- pyerr-clear-auditor — exception-clobber in the destructor family (gh-152083)
+- uninitialized-dealloc-auditor — half-built object freed on an error path (gh-151815, gh-152851)
 
 **Group B — Memory safety**:
 3. null-safety-scanner

--- a/plugins/cpython-review-toolkit/commands/health.md
+++ b/plugins/cpython-review-toolkit/commands/health.md
@@ -24,6 +24,9 @@ Run all agents in summary mode to produce a quick health dashboard. Each agent r
 | Dimension          | Status      | Score | FIX | Top Finding                    |
 |--------------------|-------------|-------|-----|--------------------------------|
 | Refcount Safety    | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| Recursion Guards   | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| Destructor PyErr   | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| Uninit Dealloc     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Error Handling     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | GIL Discipline     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Complexity         | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |

--- a/plugins/cpython-review-toolkit/commands/hotspots.md
+++ b/plugins/cpython-review-toolkit/commands/hotspots.md
@@ -6,7 +6,7 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 
 # CPython C Code Hotspots
 
-Run the three highest-value agents to find the worst functions to fix first: **c-complexity-analyzer**, **refcount-auditor**, and **error-path-analyzer**. Answers the question: "Where should I focus my review efforts?"
+Run the highest-value agents to find the worst functions to fix first: the crash-class detectors plus **c-complexity-analyzer**, **refcount-auditor**, and **error-path-analyzer**. Answers the question: "Where should I focus my review efforts?"
 
 **Scope:** "$ARGUMENTS" (default: entire project)
 
@@ -15,6 +15,9 @@ Run the three highest-value agents to find the worst functions to fix first: **c
 1. Identify CPython project root
 2. Run **include-graph-mapper** first (structural context)
 3. Run with at most 2 agents in parallel, feeding context:
+   - **recursion-guard-auditor** — native-stack-overflow SIGSEGV in recursion-prone slots
+   - **pyerr-clear-auditor** — exception-clobber in the destructor family
+   - **uninitialized-dealloc-auditor** — half-built object freed on an error path
    - **refcount-auditor** — find reference counting errors
    - **error-path-analyzer** — find error handling bugs
    - **c-complexity-analyzer** — find the hardest-to-maintain code

--- a/plugins/cpython-review-toolkit/commands/informed-explore.md
+++ b/plugins/cpython-review-toolkit/commands/informed-explore.md
@@ -1,0 +1,114 @@
+---
+description: "Like `explore`, but INFORMED: every agent first reads a briefing of recurring CPython C bug SHAPES (sibling-hunt templates with their guarded twins), the cross-cutting triage rules, and the false-positive taxonomy — so it confirms-without-relitigating, suppresses known FPs, and hunts un-found siblings of known shapes instead of re-discovering from scratch. Use for a thorough audit, a re-review of a subsystem, or whenever fix-propagation matters more than raw speed."
+argument-hint: "[scope] [aspects] [options]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
+---
+
+# Informed CPython C Code Exploration
+
+Same coverage as [`explore`](explore.md), but **informed**: every agent is seeded with the toolkit's
+accumulated knowledge before it triages. That is what turns a cold, re-discovering pass into a
+fix-propagation sweep — finding *every* instance of a known bug shape and naming the guarded twin that
+fixes it. Validated pattern, ported from the sibling toolkits' informed runs.
+
+**Arguments:** "$ARGUMENTS"
+
+**Plugin root:** `<plugin_root>` is the `plugins/cpython-review-toolkit/` directory — this command
+file's grandparent. Resolve it relative to this file.
+
+## Argument Parsing
+
+Identical to `explore`: **scope** (path or glob, default the whole checkout), **aspects** (the same
+aspect→agent table as `explore.md`, default `all`), and **options** (`deep`, `summary`, `parallel`,
+`--max-parallel N`).
+
+## Execution Workflow
+
+### Phase 0 — Project Discovery
+Exactly as `explore` Phase 0: identify the CPython root (`Include/Python.h` + `Objects/object.c`),
+count `.c`/`.h` files in scope, read the version from `Include/patchlevel.h`, print a brief scope
+summary.
+
+### Phase 0.5 — Build the informed briefing  ← the new step
+
+```
+python <plugin_root>/scripts/build_informed_briefing.py > reports/preflight/informed_briefing.md
+```
+
+If you keep the durable findings repo
+([`cpython-review-findings`](https://github.com/devdanzin/cpython-review-findings)) checked out — the
+static analog of the `cpython-oom-findings` / `cpython-tsan-findings` repos — add
+`--catalog-dir <path-to-cpython-review-findings>` to fold its `reports/*/meta.json` entries into the
+briefing as "confirm, don't re-litigate" leads, so a re-review is cumulative.
+
+This assembles a Markdown briefing from three catalogs:
+- **`data/cpython_bug_shapes.json`** — recurring CPython C bug SHAPES, each with its **guarded twin**
+  (the correctly-handled sibling = the fix), a sibling-hunt directive, a confirming differential, and
+  which scanner surfaces it.
+- The **cross-cutting triage rules** (guarded-twin-is-the-signal, both-crash ≠ acceptable,
+  reachability-first, confirm-don't-relitigate, Class-J out of scope).
+- **`data/cpython_non_bugs.md`** — the false-positive taxonomy, reproduced inline.
+
+Read `reports/preflight/informed_briefing.md` yourself before dispatching, and print the shape count
+and whether a catalog dir was folded in.
+
+### Phase 1 — Foundational Context (always runs first)
+Dispatch **include-graph-mapper** with the scope, exactly as `explore` Phase 1. Store its output for
+injection into Phase 2.
+
+### Phase 2 — Targeted Analysis (informed)
+
+Dispatch the aspect agents in the **same groups A–E as `explore`** (Safety-critical → Crash-class
+detectors → Memory safety → Code quality → Maintenance → History). In addition to the scope and the
+include-graph-mapper output, give **every** agent the contents of
+`reports/preflight/informed_briefing.md` and these instructions:
+
+> **Read the informed briefing first.** Then run your scanner and triage in informed mode:
+> 1. **Confirm, don't re-litigate** a previously-recorded finding — tally it in one line and move on.
+> 2. **Skip the false-positive classes** in the taxonomy; if you flag one of those shapes anyway, you
+>    must justify why *this* instance is not that FP class.
+> 3. **Hunt siblings** of the bug SHAPES relevant to you: for each finding, name its **guarded twin**
+>    (the correctly-handled sibling in the same file/family = the fix), and search for the other sites
+>    that lack it. New siblings + new territory are the goal, not re-describing the catalog. Where a
+>    differential is listed for the shape, run it to confirm or kill the lead.
+
+Groups run sequentially (History last, so it can cross-reference the others); `parallel` runs agents
+*within* a group concurrently, capped by `--max-parallel`.
+
+### Phase 3 — Synthesis
+
+Produce the unified report exactly as `explore` Phase 3 (same summary template), with two additions:
+1. A **"New siblings of known shapes"** subsection — the fix-propagation yield (the highest-value
+   output of an informed run), each paired with its guarded twin.
+2. A **"Classes bounded"** note — shapes you checked and found the scope is *clean* on (a negative a
+   cold run never states).
+
+If a finding is confirmed as novel and worth recording, add it to the `cpython-review-findings` repo
+(the `reports/<id>/meta.json` layout) so the next informed run is seeded with it. Check the CPython
+tracker (`label:type-crash`) for prior art before calling anything novel — a native-stack overflow or
+UAF is frequently already known.
+
+## Extending the catalogs
+
+- A **new recurring bug shape** → add an entry to `data/cpython_bug_shapes.json` (`id`, `title`,
+  `pattern`, `guarded_twin`, `hunt`, `severity`, `differential`, `scanner`). It becomes a sibling-hunt
+  template for every future run.
+- A **new false-positive class** confirmed in triage → add it to `data/cpython_non_bugs.md`. This is
+  the feedback that keeps precision from decaying.
+
+## Usage Examples
+
+```
+/cpython-review-toolkit:informed-explore
+/cpython-review-toolkit:informed-explore Objects/ recursion pyerr-clear
+/cpython-review-toolkit:informed-explore Modules/_io/ all deep parallel
+/cpython-review-toolkit:informed-explore . all --catalog-dir ~/projects/cpython-review-findings
+```
+
+## When to use `explore` vs `informed-explore`
+
+- **`explore`** — a fast first pass on an unfamiliar subsystem, or when you want raw scanner output
+  without the catalog framing.
+- **`informed-explore`** — a thorough audit, a re-review of code you've seen before (the findings repo
+  makes it cumulative), or whenever fix-propagation (find *every* instance of a known shape) matters
+  more than speed.

--- a/plugins/cpython-review-toolkit/commands/known-issues.md
+++ b/plugins/cpython-review-toolkit/commands/known-issues.md
@@ -1,0 +1,85 @@
+---
+description: "Cross-reference the seed catalog of previously-found CPython crashes against a fresh scan, so a fix (or a regression-after-revert) is detected. Static, drift-tolerant regression — no repros run."
+argument-hint: "[scope]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
+---
+
+# CPython Known-Issues Regression
+
+`data/cpython_known_bugs.tsv` records crash sites previously confirmed in CPython — from the findings repos (`OOM-####`, `TSAN-####`) and the upstream tracker (`gh-NNNNNN`). This command runs, per catalog entry, the scanner matching that entry's category over the referenced file and reports whether the known bug is still in the tree.
+
+It is **static and drift-tolerant** — it does not run repros. It answers: "of the crashes we already know about, which are still present at this checkout, which have drifted, and which look fixed?"
+
+**Scope:** "$ARGUMENTS" (path or glob; default the whole project). The scope's checkout root is auto-detected — catalog paths are resolved relative to it, so a narrow scope still locates the right files.
+
+**Plugin root:** `<plugin_root>` is the `plugins/cpython-review-toolkit/` directory.
+
+## Category → scanner map
+
+| Category | Scanner |
+|----------|---------|
+| `recursion` | `scan_recursion_guards.py` |
+| `pyerr-clear` | `scan_pyerr_clear.py` |
+| `uninit-dealloc` | `scan_uninit_dealloc.py` |
+| `null-deref` | `scan_null_checks.py` |
+| `refcount` | `scan_refcounts.py` |
+| `tsan`, `init-bypass` | *(no scanner in v0.5 → `no_scanner`)* |
+
+## Workflow
+
+1. **Cross-reference:**
+   ```
+   python <plugin_root>/scripts/check_known_issues.py [scope]
+   ```
+   Optional flags: `--max-files N`, `--catalog <path>` (override the default TSV).
+   Record the reviewed commit (`git -C <project_root> rev-parse --short HEAD`) — the catalog was captured at a slightly different commit, so line drift is expected.
+
+2. **Read the `catalog_results` / `bug_rollup` blocks.** Each entry gets one of:
+   - **`present`** — a finding of that category at (or within ±5 lines of) the catalog line, or — when the catalog line is unknown (`0`) — a finding in the named function. Still unfixed. → high confidence.
+   - **`line_drifted`** — the file still has findings of that category but not at the catalog site; `nearest_line` points at the closest one. The bug likely just moved a few lines. → medium.
+   - **`absent`** — the file was scanned and has no findings of that category (likely fixed or refactored).
+   - **`file_missing`** — the path no longer exists under the checkout.
+   - **`no_scanner`** — `tsan` / `init-bypass` categories have no scanner in v0.5; carried through for completeness, not cross-referenced.
+
+   The `bug_rollup` collapses a multi-site bug's sites into one verdict (`present` / `line_drifted` / `likely_fixed` / `no_scanner`).
+
+3. **Verify the drifted and absent ones.** For each `line_drifted` bug, Read the file around `nearest_line` and confirm the same bug shape. For each `absent` bug, Read the file to confirm the bug is actually gone.
+
+> **Caveat (baked into the JSON `notes` field, repeated here):** an `absent` verdict is **NOT** proof of a fix. Some crash shapes carry no scannable token at the exact site — a native C-stack overflow (`recursion`), a data race (`tsan`) — so a fresh scan can read a still-unfixed bug as `absent`. **Always read the file before concluding a bug is fixed.** Likewise, `no_scanner` entries (`tsan`, `init-bypass`) are never cross-referenced and must be checked by hand.
+
+## Output
+
+```markdown
+# Known-Issues Regression — CPython @ [commit]
+
+Catalog: [N] entries, [B] distinct bugs, [F] files scanned.
+
+| Bug | Verdict | Site(s) | Notes |
+|-----|---------|---------|-------|
+| gh-154318 | present | Objects/tupleobject.c:tuple_hash | copy-pasted guardless hash; deep tuple -> C-stack SIGSEGV |
+| gh-154275 | line_drifted | Objects/genericaliasobject.c:~231 | parameter walk, nearest finding a few lines off |
+| OOM-0023  | likely_fixed | Objects/typeobject.c:subtype_dealloc | read the file to confirm |
+| TSAN-0053 | no_scanner | Objects/dictobject.c:6158 | no tsan scanner in v0.5 — check by hand |
+| ... | | | |
+
+**Still present: [n]**   **Drifted: [m]**   **Likely fixed: [k]**   **No scanner: [j]**
+
+## Confirmed still-present (act on these)
+[List the `present` bugs — the highest-confidence regression signals.]
+
+## Likely fixed since the catalog
+[List the `absent` / `file_missing` bugs — verify each by reading the file.]
+
+## Not cross-referenced (manual check required)
+[List the `no_scanner` bugs — tsan / init-bypass.]
+```
+
+Note: a `present` verdict means a previously-confirmed crash site is still in the tree. When sharing upstream, follow `WORKING_WITH_MAINTAINERS.md` and cite the catalog `bug_id`.
+
+## Usage
+
+```
+/cpython-review-toolkit:known-issues                 # whole project
+/cpython-review-toolkit:known-issues Objects/         # scope to Objects/
+/cpython-review-toolkit:known-issues . --max-files 200
+```

--- a/plugins/cpython-review-toolkit/data/cpython_bug_shapes.json
+++ b/plugins/cpython-review-toolkit/data/cpython_bug_shapes.json
@@ -1,0 +1,79 @@
+{
+  "_comment": "Reusable CPython C bug SHAPES (not file:line) for the informed-explore loop. Each shape carries a guarded_twin (the correct sibling = the fix), a hunt directive (how to find more), a differential (how to confirm), and confirmed_examples. Consumed by build_informed_briefing.py.",
+  "version": "0.5.0",
+  "shapes": [
+    {
+      "id": "unguarded-recursion-in-slot",
+      "title": "Recursion-prone slot without Py_EnterRecursiveCall",
+      "pattern": "A tp_hash / tp_richcompare / tp_repr / tp_str slot (or a generic-alias parameter walk) that descends a user-controlled object graph — self-recursion, or a loop calling PyObject_Hash/Repr/RichCompare on items — with no Py_EnterRecursiveCall / Py_ReprEnter.",
+      "guarded_twin": "A sibling slot in the same file that DOES bracket its descent with Py_EnterRecursiveCall()/Py_LeaveRecursiveCall() or Py_ReprEnter()/Py_ReprLeave().",
+      "hunt": "For every container/aggregate type, check tp_hash, tp_richcompare, tp_repr, tp_str for symmetry: if repr is guarded but hash is not, hash is suspect. Grep for copy-pasted hash algorithms across container types.",
+      "severity": "FIX",
+      "differential": "Build a deeply-nested or self-referential instance on a debug CPython and trigger the slot; a SIGSEGV (not RecursionError) confirms. A native stack overflow is a bug even if released CPython also crashes.",
+      "confirmed_examples": ["gh-154318 tuple_hash/frozendict_hash", "gh-154275 _Py_make_parameters", "gh-149146 tuple_dealloc"],
+      "scanner": "scan_recursion_guards.py"
+    },
+    {
+      "id": "pyerr-clear-in-destructor",
+      "title": "PyErr_Clear() clobbers an in-flight exception during teardown",
+      "pattern": "A tp_dealloc / tp_clear / tp_finalize calls PyErr_Clear() (or drops a fallible result) with no surrounding save/restore of the exception state; the destructor can run while an exception is already pending.",
+      "guarded_twin": "A destructor that captures with PyErr_GetRaisedException() at the top and restores with PyErr_SetRaisedException() at the bottom (or reports via PyErr_WriteUnraisable).",
+      "hunt": "Across a module family, check every dealloc/clear/finalize that calls a fallible API on a cleanup path; the ones that PyErr_Clear() without save/restore swallow MemoryError/KeyboardInterrupt.",
+      "severity": "FIX",
+      "differential": "Under set_nomemory OOM injection, raise MemoryError, then trigger the teardown; the swallowed error becomes a silent success/hang.",
+      "confirmed_examples": ["gh-152083 context_tp_dealloc", "OOM-0039 deque_clear", "OOM-0023 subtype_dealloc"],
+      "scanner": "scan_pyerr_clear.py"
+    },
+    {
+      "id": "dealloc-of-uninitialized-object",
+      "title": "Half-constructed object freed on an error path",
+      "pattern": "A constructor allocates via a non-zeroing allocator (PyObject_New/PyObject_GC_New/...), then on a fallible-step failure Py_DECREFs the object before its members are NULL-initialized; tp_dealloc reads garbage member pointers.",
+      "guarded_twin": "A constructor that NULL-initializes all members (or memsets the object) immediately after allocation, before any fallible call.",
+      "hunt": "For each non-zeroing allocation with an error path that frees the object, read the tp_dealloc: if it Py_XDECREFs / switches-on-enum a member the constructor sets late, it crashes on that path.",
+      "severity": "FIX",
+      "differential": "set_nomemory to fail the exact allocation on the error path, then construct from Python; a crash in tp_dealloc confirms (OOM class O5).",
+      "confirmed_examples": ["gh-151815 template_iter", "gh-152851 blake2 .copy()"],
+      "scanner": "scan_uninit_dealloc.py"
+    },
+    {
+      "id": "borrowed-ref-across-call",
+      "title": "Borrowed reference used across a call that can free it (crown jewel)",
+      "pattern": "A borrowed pointer loaded from a slot field or container (PyList/Tuple/Dict_GET_ITEM) is used after an intervening call that can run arbitrary Python (PyObject_Call*, PyObject_Repr/Str, converter callbacks like PyUnicode_FSConverter, warnings, GC) with no intervening Py_INCREF.",
+      "guarded_twin": "The same access pattern elsewhere that Py_INCREFs the borrowed ref before the call and Py_DECREFs after.",
+      "hunt": "Trace every borrowed load feeding a call that can execute Python; the free may come from a __del__, __fspath__, setcontext, or a re-entrant callback.",
+      "severity": "FIX",
+      "differential": "Supply an adversarial object whose callback drops the last strong ref (mutating __fspath__/__eq__/__index__), then observe UAF on ASan.",
+      "confirmed_examples": ["gh-148382 _decimal CURRENT_CONTEXT", "gh-151403 _posixsubprocess __fspath__", "gh-154527 defaultdict default_factory (FT)"],
+      "scanner": "scan_refcounts.py (widen the Python-reaching call set)"
+    },
+    {
+      "id": "return-null-without-exception",
+      "title": "Return NULL without setting an exception / stale-exception desync",
+      "pattern": "A PyObject*-returning function returns NULL with no prior PyErr_Set*, or an entry point trusts res!=NULL while PyErr_Occurred() is set.",
+      "guarded_twin": "Sibling error paths in the same function that set an exception before returning NULL.",
+      "hunt": "OOM paths are the usual offenders — a constructor whose allocation-failure branch returns NULL but forgets PyErr_NoMemory().",
+      "severity": "FIX",
+      "differential": "set_nomemory to force the failure; a SystemError('returned NULL without setting an exception') confirms.",
+      "confirmed_examples": ["gh-151968", "gh-151126 (missing PyErr_NoMemory cluster)"],
+      "scanner": "scan_error_paths.py (return_null_no_exception)"
+    },
+    {
+      "id": "integer-overflow-in-allocation",
+      "title": "Allocation size from a Python-controlled multiply with no overflow guard",
+      "pattern": "PyMem_*/malloc(n * size) where n derives from a Py_ssize_t parsed from Python args, with no `n > MAX/size` guard and no safe-multiply helper.",
+      "guarded_twin": "Sibling allocations that use PyMem_New / a checked multiply / an explicit bound.",
+      "hunt": "Every length/count argument that reaches an allocation multiply is a candidate; abort-vs-MemoryError is out of scope, wrong-size-then-write is the bug.",
+      "severity": "CONSIDER",
+      "differential": "Pass a length near SIZE_MAX/elem; a segfault (vs a clean MemoryError) confirms the overflow.",
+      "confirmed_examples": ["gh-3493", "gh-1779"],
+      "scanner": "memory-pattern-analyzer (promote to a real scanner in a later slice)"
+    }
+  ],
+  "triage_rules": [
+    "The guarded twin is the strongest static-review signal: nearly every real CPython bug has a correctly-handled sibling in the same file — cite it as the fix and hunt for other unfixed siblings.",
+    "Both-crash != acceptable: if the differential shows released CPython ALSO crashes on the input, that is not proof it is fine — search the CPython tracker (label:type-crash) and treat a pure-Python-reachable segfault as a bug in both.",
+    "Reachability first: rank a candidate by whether its triggering value flows from Python-controlled input (a parsed arg, a user __index__/__hash__/__repr__, a user-supplied index/length) vs an internal invariant (assert / 'cannot fail').",
+    "Confirm-don't-relitigate: a finding already recorded in the findings catalog is context, not a fresh discovery — confirm it still reproduces and move on to siblings.",
+    "Class J (abort-vs-MemoryError) is out of scope; a wrong-size write or a swallowed error is in scope."
+  ]
+}

--- a/plugins/cpython-review-toolkit/data/cpython_known_bugs.tsv
+++ b/plugins/cpython-review-toolkit/data/cpython_known_bugs.tsv
@@ -1,0 +1,46 @@
+# cpython_known_bugs.tsv — regression catalog for the `known-issues` command.
+#
+# Seed catalog of previously-found CPython crashes, cross-referenced against a
+# fresh scan so a fix (or a regression-after-revert) is detected. Regenerate /
+# extend from the findings repos (cpython-oom-findings, cpython-tsan-findings)
+# and the CPython tracker as new bugs land.
+#
+# Columns (TAB-separated):
+#   bug_id     upstream issue (gh-NNNNNN) or findings-repo id (OOM-####, TSAN-####)
+#   path       repo-relative C source path
+#   line       1-indexed line, or 0 if unknown (match by function/category)
+#   category   recursion | pyerr-clear | uninit-dealloc | null-deref | refcount | tsan | init-bypass
+#   function   enclosing function (for line-drift-tolerant matching)
+#   note       short description / status
+#
+# NOTE: some crash shapes carry no scannable token at the exact site (a native
+# stack overflow, a data race). For those, `absent` against a fresh scan is NOT
+# proof of a fix — read the file. See the `known-issues` command docs.
+#
+# bug_id	path	line	category	function	note
+gh-154318	Objects/tupleobject.c	0	recursion	tuple_hash	copy-pasted guardless hash; deep/cyclic tuple -> C-stack SIGSEGV
+gh-154318	Objects/tupleobject.c	0	recursion	tuple_richcompare	sibling of tuple_hash, element descent w/o guard
+gh-154275	Objects/genericaliasobject.c	231	recursion	_Py_make_parameters	self-recursive parameter walk, no Py_EnterRecursiveCall
+gh-154318	Objects/unionobject.c	0	recursion	union_hash	sibling class surfaced by recursion-guard-auditor
+gh-149146	Objects/tupleobject.c	0	recursion	tuple_dealloc	recursion during MemoryError unwind
+gh-151815	Objects/templateobject.c	225	uninit-dealloc	template_iter	non-zeroing alloc freed before member init
+gh-152851	Modules/blake2module.c	0	uninit-dealloc	py_blake2_clear	.copy() frees object with uninitialized impl enum
+gh-152083	Python/context.c	0	pyerr-clear	context_tp_dealloc	clears pending exception during teardown
+OOM-0039	Modules/_collectionsmodule.c	750	pyerr-clear	deque_clear	newblock-fail PyErr_Clear swallows in-flight error
+OOM-0023	Objects/typeobject.c	0	pyerr-clear	subtype_dealloc	clears pending exception in dealloc
+gh-151673	Python/_warnings.c	0	null-deref	do_warn	unchecked PyUnicode_FromString on OOM path
+gh-151798	Parser/pegen.c	33	null-deref	_PyPegen_run_parser	unchecked PyUnicode_AsUTF8 deref
+gh-154385	Modules/readline.c	0	null-deref	0	unchecked PyLong_FromLong stored then Py_NewRef(NULL)
+gh-153800	Modules/_sqlite/connection.c	0	null-deref	0	window agg NULL deref on empty frame
+gh-152954	Modules/_sqlite/connection.c	0	init-bypass	0	Connection.__new__ bypass -> NULL row_factory INCREF
+gh-152817	Modules/_sqlite/cursor.c	0	init-bypass	0	del cursor.row_factory -> NULL vectorcall
+gh-151818	Python/bytecodes.c	0	refcount	_CALL_LIST_APPEND	list.append grow-fail double-free under MemoryError
+gh-152951	Modules/_collectionsmodule.c	0	refcount	deque_extend	block-alloc-fail double-DECREF
+gh-153210	Modules/arraymodule.c	0	refcount	array_modexec	error during import -> double-DECREF ArrayType
+gh-148382	Modules/_decimal/_decimal.c	0	refcount	current_context	borrowed CURRENT_CONTEXT across callbacks (UAF)
+gh-151403	Modules/posixmodule.c	0	refcount	os_posix_spawn	borrowed argv item freed by __fspath__
+TSAN-0053	Objects/dictobject.c	6158	tsan	dictiter_iternextitem	shared dict iterator double-DECREF (gh-154130)
+TSAN-0054	Objects/setobject.c	1130	tsan	setiter_iternext	shared set iterator double-DECREF (gh-144357)
+TSAN-0033	Modules/_asynciomodule.c	2963	tsan	TaskObj_dealloc	finalize before GC_UnTrack (gh-153809)
+TSAN-0006	Modules/itertoolsmodule.c	0	tsan	count_repr	plain read of atomically-written cnt
+TSAN-0043	Objects/descrobject.c	0	tsan	descr_get_qualname	lazy-init cache without critical section

--- a/plugins/cpython-review-toolkit/data/cpython_non_bugs.md
+++ b/plugins/cpython-review-toolkit/data/cpython_non_bugs.md
@@ -1,0 +1,65 @@
+# CPython false-positive taxonomy (cpython-review-toolkit)
+
+The precision-decay guard for the informed-explore loop. Each entry is a pattern
+the scanners *can* surface but that is usually **not** a bug in CPython's own
+code. During triage, skip these classes — or explicitly justify why this instance
+is different. Add to this file whenever a review confirms a new FP class.
+
+---
+
+## PyErr_Clear / exception state
+
+- **`PyErr_Clear()` after a sentinel-returning lookup is idiomatic.** After
+  `PyObject_GetAttr` / `PyDict_GetItemWithError` / `PyMapping_GetOptionalItem`
+  where a missing key is expected, clearing an `AttributeError`/`KeyError` is
+  correct — *outside* the destructor family. The `pyerr-clear-auditor` is scoped
+  to dealloc/clear/finalize precisely to avoid this; a hit there is real.
+- **A destructor that already saves/restores** (`PyErr_GetRaisedException` /
+  `PyErr_Fetch` / `PyErr_WriteUnraisable`) is fine — but verify the save/restore
+  actually brackets the flagged clear in a large function (whole-function
+  suppression can hide a second, unguarded clear).
+
+## Recursion guards
+
+- **Guarded by the dispatcher.** A leaf slot reached only through
+  `PyObject_Repr`/`PyObject_Hash`/`PyObject_RichCompare`, which already wrap
+  `Py_EnterRecursiveCall`, is safe *if it is never reached directly*. Confirm the
+  call graph before dismissing.
+- **Non-nestable receiver.** A `*_hash`/`*_repr` on a type whose elements can
+  never be the same or another container (e.g. a code object's fixed fields) can
+  descend without a guard because the depth is bounded. ACCEPTABLE — but state
+  the bound.
+- **`Py_TRASHCAN` / iterative deallocation** already bounds a `tp_dealloc`; a
+  recursion finding on a trashcan-protected dealloc is a FP.
+
+## Uninitialized dealloc
+
+- **Zeroing allocator.** `type->tp_alloc(type, n)` / `PyType_GenericAlloc` /
+  `*_GC_Calloc` zero the object; a following early free is safe. The scanner
+  excludes these, but a wrapper macro may hide one.
+- **`tp_dealloc` guards each member with `Py_XDECREF`** *and* the members were
+  NULL-initialized before the failing step — Py_XDECREF(NULL) is a no-op, so no
+  crash. Only a member left as *garbage* (not NULL) at the free point is a bug.
+
+## NULL checks / error paths
+
+- **Infallible-by-construction returns.** `Py_None`/`Py_True`/`Py_False`, interned
+  singletons, and `_Py_ID(...)` never return NULL; a missing check is not a bug.
+- **Checked via a macro the scanner doesn't model.** `Py_SETREF` / `Py_XSETREF`
+  and `Py_CLEAR` handle NULL internally; assignments through them are safe.
+
+## Refcounts
+
+- **Borrowed ref under a known-live owner.** A borrowed item is safe across a call
+  if a strong reference is provably held elsewhere for the duration (e.g. the
+  container is a local the callee cannot reach). Establish the owner before
+  dismissing a borrowed-across-call finding.
+- **Stolen-ref APIs used correctly.** `PyList_SET_ITEM`/`PyTuple_SET_ITEM` on a
+  freshly-created, not-yet-published container are the normal fast path.
+
+## Free-threading (when the FT detectors land)
+
+- **Immortal objects** (`_Py_IMMORTAL_REFCNT`) are not raced by refcount ops.
+- **Access under `Py_BEGIN_CRITICAL_SECTION`** for the relevant object is
+  protected; a plain read is only a race if a *concurrent* writer exists without
+  the same critical section.

--- a/plugins/cpython-review-toolkit/data/cpython_reachability_sources.json
+++ b/plugins/cpython-review-toolkit/data/cpython_reachability_sources.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Reachability tiering + input-provenance signals to rank CPython C findings. The candidate count on CPython is inherently huge; this turns a flat dump into a ranked list. Tiers are stamped by the source mapper; provenance signals up/down-weight individual findings.",
+  "version": "0.5.0",
+  "tiers": {
+    "T1_python_exposed": {
+      "weight": 3,
+      "description": "Directly reachable from a Python program: functions registered in PyMethodDef / PyGetSetDef / PyMemberDef arrays, or wired to a tp_* / nb_* / sq_* / mp_* slot, or a module-level PyCFunction. A crash here is directly triggerable.",
+      "signals": ["PyMethodDef", "PyGetSetDef", "PyMemberDef", "PyType_Slot", "tp_", "nb_", "sq_", "mp_", "METH_"]
+    },
+    "T2_public_capi": {
+      "weight": 2,
+      "description": "Public C-API reachable by extensions/embedders: PyAPI_FUNC / Py* exported symbols. Reachable, but the caller shares responsibility for preconditions.",
+      "signals": ["PyAPI_FUNC", "PyAPI_DATA"]
+    },
+    "T3_internal": {
+      "weight": 1,
+      "description": "Internal helpers: _Py* / static functions, reached only transitively and often with caller-guaranteed preconditions. Default-quieter unless a T1/T2 caller passes user input straight through.",
+      "signals": ["static ", "_Py", "_PyObject", "_PyErr"]
+    }
+  },
+  "input_provenance": {
+    "_comment": "A finding is strong when a high-weight provenance signal sits on a T1/T2 site — the failing value flows from Python-controlled input.",
+    "parsed_argument": {
+      "weight": 3,
+      "tokens": ["PyArg_ParseTuple", "PyArg_ParseTupleAndKeywords", "PyArg_Parse", "PyArg_UnpackTuple", "_PyArg_ParseStack"]
+    },
+    "user_index_or_length": {
+      "weight": 3,
+      "tokens": ["PyLong_AsSsize_t", "PyLong_AsLong", "PyNumber_AsSsize_t", "__index__", "PyObject_Length", "PyObject_Size"]
+    },
+    "user_dunder_callback": {
+      "weight": 3,
+      "tokens": ["PyObject_Hash", "PyObject_RichCompare", "PyObject_RichCompareBool", "PyObject_Repr", "PyObject_Str", "PyObject_GetIter", "PyIter_Next", "__eq__", "__hash__", "__index__", "__repr__"]
+    },
+    "converter_callback": {
+      "weight": 3,
+      "tokens": ["PyUnicode_FSConverter", "PyUnicode_FSDecoder", "PyObject_GetBuffer", "PyArg_Parse\"O&\""]
+    },
+    "reentrant_or_gc": {
+      "weight": 2,
+      "tokens": ["PyObject_CallFunction", "PyObject_CallMethod", "PyObject_Call", "PyObject_Vectorcall", "PyErr_WarnEx", "PyImport_Import", "PyObject_GC_New"]
+    }
+  },
+  "weak_internal_signals": {
+    "_comment": "These LOWER confidence — the failing condition is an internal invariant, not Python-reachable input.",
+    "tokens": ["assert(", "Py_UNREACHABLE", "cannot fail", "can't fail", "should never", "just created", "just inserted", "_PyErr_Occurred"]
+  }
+}

--- a/plugins/cpython-review-toolkit/scripts/build_informed_briefing.py
+++ b/plugins/cpython-review-toolkit/scripts/build_informed_briefing.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Assemble the informed-explore briefing from the CPython bug-shape catalogs.
+
+This is a **generator**, not a scanner: it emits a **Markdown briefing** (to
+stdout) that every agent in the ``informed-explore`` command reads first. It is
+the deterministic, reusable form of the hand-built briefing that proved out in
+the sibling toolkits' informed runs. It seeds each agent with
+
+  (a) the bug-SHAPE catalog (``data/cpython_bug_shapes.json``) as sibling-hunt
+      templates, each with its **guarded twin** (the correct sibling = the fix),
+  (b) the cross-cutting triage rules (guarded-twin, both-crash, reachability,
+      confirm-don't-relitigate), and
+  (c) the false-positive taxonomy (``data/cpython_non_bugs.md``) to suppress.
+
+The bug shapes are CPython-INDEPENDENT of any single module, so one briefing
+applies to any scope of a CPython checkout. If a durable findings repo
+(``cpython-review-findings``, the static analog of ``cpython-oom-findings`` /
+``cpython-tsan-findings``) is checked out, pass ``--catalog-dir`` to fold its
+``reports/*/meta.json`` entries in as "confirm, don't re-litigate" leads.
+
+Output is Markdown, not JSON, because it is consumed directly as an agent
+briefing::
+
+    python build_informed_briefing.py > reports/preflight/informed_briefing.md
+    python build_informed_briefing.py --catalog-dir ~/projects/cpython-review-findings
+
+The CLI shape mirrors ``scan_common.parse_common_args`` (a small hand-rolled
+flag loop, writes to stdout, exposes ``main()``), but there is no positional
+target and no ``--max-files``: the briefing is target-independent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_DATA = Path(__file__).resolve().parent.parent / "data"
+_DEFAULT_SHAPES = _DATA / "cpython_bug_shapes.json"
+_DEFAULT_NON_BUGS = _DATA / "cpython_non_bugs.md"
+
+
+# ---------------------------------------------------------------------------
+# Catalog loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_shapes(shapes_path: str | None = None) -> dict:
+    """Load ``cpython_bug_shapes.json`` → ``{"shapes": [...], "triage_rules": [...]}``.
+
+    A missing/invalid file yields empty lists (the briefing degrades gracefully
+    rather than crashing an entire informed run).
+    """
+    path = Path(shapes_path) if shapes_path else _DEFAULT_SHAPES
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"shapes": [], "triage_rules": []}
+    shapes = [s for s in data.get("shapes", []) if isinstance(s, dict) and s.get("id")]
+    rules = [r for r in data.get("triage_rules", []) if isinstance(r, str)]
+    return {"shapes": shapes, "triage_rules": rules}
+
+
+def _load_non_bugs(non_bugs_path: str | None = None) -> str:
+    """Return the FP-taxonomy markdown (``data/cpython_non_bugs.md``)."""
+    path = Path(non_bugs_path) if non_bugs_path else _DEFAULT_NON_BUGS
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _first_site(meta: dict) -> str:
+    """Best-effort single-site string from a findings-repo ``meta.json``.
+
+    Tolerates the two documented layouts (``sites`` list / ``signature``) plus
+    the ``signatures`` list some repos use, and a dict-shaped ``signature``.
+    """
+    sites = meta.get("sites")
+    if isinstance(sites, list) and sites:
+        return str(sites[0])
+    sigs = meta.get("signatures")
+    if isinstance(sigs, list) and sigs:
+        return str(sigs[0])
+    sig = meta.get("signature")
+    if isinstance(sig, dict):
+        return str(sig.get("site_frame") or next(iter(sig.values()), "-"))
+    if isinstance(sig, str) and sig:
+        return sig
+    return "-"
+
+
+def _load_catalog(catalog_dir: str) -> list[dict]:
+    """Fold in recorded findings from a ``cpython-review-findings`` repo.
+
+    Reads ``<catalog_dir>/reports/*/meta.json`` (the findings-repo layout) and
+    maps each entry to the briefing shape (id / category / site / title /
+    status). A missing/empty dir yields an empty list so the caller omits the
+    section entirely.
+    """
+    out: list[dict] = []
+    for meta_path in sorted(Path(catalog_dir).glob("reports/*/meta.json")):
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not meta.get("id"):
+            continue
+        out.append(
+            {
+                "id": meta["id"],
+                "category": meta.get("category", "-"),
+                "site": _first_site(meta),
+                "title": meta.get("title", meta.get("slug", "")),
+                "status": meta.get("status", "confirmed"),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Markdown assembly
+# ---------------------------------------------------------------------------
+
+_INFORMED_RULES = (
+    "1. **Confirm, don't re-litigate.** If a candidate matches a "
+    "previously-recorded finding (the catalog section below, if present), tally "
+    "it in one line and move on — do not re-describe a known bug.\n"
+    "2. **Skip the known false-positive classes** (the taxonomy below). If you "
+    "flag something that falls in one of those classes, you must say *why this "
+    "instance is NOT that FP class*.\n"
+    "3. **Hunt siblings via the guarded twin.** For each bug SHAPE relevant to "
+    "your scope, locate its **guarded twin** (the correctly-handled sibling in "
+    "the same file/family = the fix), then search for the other sites that lack "
+    "it — those un-found siblings are the point of an informed run."
+)
+
+
+def _escape_cell(text: str) -> str:
+    return str(text).replace("|", r"\|").replace("\n", " ")
+
+
+def _render_shape(shape: dict) -> str:
+    lines = [
+        f"### {shape['id']} — {shape.get('title', '')}",
+        f"- **severity (default before triage):** {shape.get('severity', 'CONSIDER')}",
+        f"- **pattern:** {shape.get('pattern', '')}",
+        f"- **guarded twin (the fix):** {shape.get('guarded_twin', '')}",
+        f"- **hunt:** {shape.get('hunt', '')}",
+    ]
+    if shape.get("differential"):
+        lines.append(f"- **differential (how to confirm):** {shape['differential']}")
+    examples = shape.get("confirmed_examples") or []
+    if examples:
+        lines.append(f"- **confirmed examples:** {', '.join(examples)}")
+    if shape.get("scanner"):
+        lines.append(f"- **surfaced by:** `{shape['scanner']}`")
+    return "\n".join(lines)
+
+
+def build_briefing(
+    *,
+    shapes_path: str | None = None,
+    non_bugs_path: str | None = None,
+    catalog_dir: str | None = None,
+) -> str:
+    """Assemble the informed-explore briefing markdown (deterministic).
+
+    ``shapes_path`` / ``non_bugs_path`` override the default ``data/`` catalogs
+    (used by tests). ``catalog_dir`` optionally points at a
+    ``cpython-review-findings`` repo whose ``reports/*/meta.json`` entries are
+    folded in as recorded findings.
+    """
+    data = _load_shapes(shapes_path)
+    shapes = data["shapes"]
+    triage_rules = data["triage_rules"]
+    non_bugs_md = _load_non_bugs(non_bugs_path)
+    findings = _load_catalog(catalog_dir) if catalog_dir else []
+
+    out: list[str] = []
+    out.append("# Informed-exploration briefing — CPython C code review\n")
+    out.append(
+        "You are running as part of an **informed** explore. Unlike a cold run, "
+        "you have the catalog of recurring CPython C bug SHAPES (reusable "
+        "templates — not file:line, since the scope differs every run), the "
+        "cross-cutting triage rules, and the false-positive taxonomy. Use them: "
+        "the goal is fix-propagation (find *every* instance of a known shape) "
+        "and genuinely new territory, not re-discovering the catalog.\n"
+    )
+
+    out.append("## Your three informed-mode rules\n")
+    out.append(_INFORMED_RULES + "\n")
+
+    out.append("## Cross-cutting triage rules (apply to every finding)\n")
+    if triage_rules:
+        out.append("\n".join(f"- {rule}" for rule in triage_rules) + "\n")
+    else:
+        out.append("_(no triage rules loaded — see data/cpython_bug_shapes.json)_\n")
+
+    out.append("## Bug-shape catalog — sibling-hunt templates\n")
+    if shapes:
+        out.append(
+            f"{len(shapes)} recurring shapes. For each, the **guarded twin** is "
+            "the correctly-handled sibling that both confirms the finding and "
+            "*is* the fix.\n"
+        )
+        for shape in shapes:
+            out.append(_render_shape(shape) + "\n")
+    else:
+        out.append("_(no shapes loaded — see data/cpython_bug_shapes.json)_\n")
+
+    if findings:
+        out.append(
+            "## Previously-recorded findings (confirm, don't re-litigate; hunt siblings)\n"
+        )
+        out.append(
+            f"From the `cpython-review-findings` catalog ({len(findings)} "
+            "recorded). These are context, not fresh discoveries: confirm each "
+            "still reproduces in one line, then spend your effort on **un-found "
+            "siblings** of the same shape (via its guarded twin).\n"
+        )
+        out.append("| id | category | site | title | status |")
+        out.append("|----|----------|------|-------|--------|")
+        for f in findings:
+            out.append(
+                f"| {_escape_cell(f['id'])} "
+                f"| {_escape_cell(f['category'])} "
+                f"| `{_escape_cell(f['site'])}` "
+                f"| {_escape_cell(f['title'])} "
+                f"| {_escape_cell(f['status'])} |"
+            )
+        out.append("")
+
+    out.append(
+        "## Known false-positive classes — DO NOT re-report (justify if you flag one)\n"
+    )
+    if non_bugs_md:
+        out.append(
+            "The full taxonomy lives in `data/cpython_non_bugs.md`; it is "
+            "reproduced here so every agent sees it inline.\n"
+        )
+        out.append(non_bugs_md)
+    else:
+        out.append("_(taxonomy file missing — see data/cpython_non_bugs.md)_")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> tuple[str | None, str | None, str | None]:
+    """Parse ``[--catalog-dir DIR] [--shapes PATH] [--non-bugs PATH]``.
+
+    Modeled on ``scan_common.parse_common_args`` (a small flag loop), but with
+    no positional target: the briefing is target-independent.
+    """
+    catalog_dir: str | None = None
+    shapes_path: str | None = None
+    non_bugs_path: str | None = None
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--catalog-dir" and i + 1 < len(argv):
+            catalog_dir = argv[i + 1]
+            i += 2
+        elif arg == "--shapes" and i + 1 < len(argv):
+            shapes_path = argv[i + 1]
+            i += 2
+        elif arg == "--non-bugs" and i + 1 < len(argv):
+            non_bugs_path = argv[i + 1]
+            i += 2
+        else:
+            i += 1
+    return catalog_dir, shapes_path, non_bugs_path
+
+
+def main() -> None:
+    try:
+        catalog_dir, shapes_path, non_bugs_path = _parse_args(sys.argv[1:])
+        briefing = build_briefing(
+            shapes_path=shapes_path,
+            non_bugs_path=non_bugs_path,
+            catalog_dir=catalog_dir,
+        )
+        # Markdown, not JSON: the output IS the agent briefing (see docstring).
+        sys.stdout.write(briefing)
+    except Exception as e:  # noqa: BLE001 -- top-level guard
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/check_known_issues.py
+++ b/plugins/cpython-review-toolkit/scripts/check_known_issues.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Cross-reference the known-CPython-crash catalog against a fresh scan.
+
+Backs the ``known-issues`` command. ``data/cpython_known_bugs.tsv`` records
+crash sites previously confirmed in CPython — from the findings repos
+(``OOM-####`` / ``TSAN-####``) and the upstream tracker (``gh-NNNNNN``). Each
+row names a repo-relative C path, an enclosing function, a category, and (when
+known) a line. This script runs the category's matching scanner over each
+referenced file and reports, per catalog entry, whether the site is:
+
+  * ``present``      — a finding of that category at (or within a small drift
+                       window of) the catalog line, or — when the catalog line
+                       is unknown (0) — a finding in the named function.
+  * ``line_drifted`` — the file still has findings of that category, but not at
+                       the catalog line / named function; ``nearest_line``
+                       points at the closest one. The bug likely just moved.
+  * ``absent``       — the file was scanned and has no findings of that
+                       category (likely fixed — but see the caveat below).
+  * ``file_missing`` — the path no longer exists under the target checkout.
+  * ``no_scanner``   — the category has no scanner in v0.5 (``tsan`` /
+                       ``init-bypass``); carried through so the catalog stays
+                       complete, but not cross-referenced.
+
+This is a static, drift-tolerant regression baseline — it does NOT run repros.
+
+CAVEAT: an ``absent`` verdict is NOT proof of a fix. Some crash shapes carry no
+scannable token at the exact site — a native C-stack overflow (recursion), a
+data race (tsan) — so a fresh scan can read a still-unfixed bug as ``absent``.
+Always read the file before concluding a bug is fixed.
+
+Usage:
+    python check_known_issues.py [path] [--max-files N] [--catalog FILE]
+"""
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import scan_null_checks
+import scan_pyerr_clear
+import scan_recursion_guards
+import scan_refcounts
+import scan_uninit_dealloc
+from scan_common import build_report, parse_common_args, resolve_roots
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+_DEFAULT_CATALOG = _DATA_DIR / "cpython_known_bugs.tsv"
+
+# Category -> scanner module. ``None`` means "no scanner exists in v0.5"; such
+# entries are carried through as ``no_scanner`` so the catalog stays complete.
+CATEGORY_SCANNERS: dict[str, object] = {
+    "recursion": scan_recursion_guards,
+    "pyerr-clear": scan_pyerr_clear,
+    "uninit-dealloc": scan_uninit_dealloc,
+    "null-deref": scan_null_checks,
+    "refcount": scan_refcounts,
+    "tsan": None,
+    "init-bypass": None,
+}
+
+# ± lines tolerated around a catalog line before a match is called "drifted".
+_DRIFT = 5
+
+_ABSENCE_CAVEAT = (
+    "An `absent` verdict is NOT proof of a fix. Some crash shapes carry no "
+    "scannable token at the exact site — a native C-stack overflow (recursion), "
+    "a data race (tsan) — so a fresh scan can read a still-unfixed bug as "
+    "`absent`. Always read the file before concluding a bug is fixed."
+)
+_NO_SCANNER_CAVEAT = (
+    "Categories `tsan` and `init-bypass` have no scanner in v0.5; their entries "
+    "are carried through as `no_scanner` (informational) so the catalog stays "
+    "complete, but they are not cross-referenced against a fresh scan."
+)
+
+
+# ---------------------------------------------------------------------------
+# Catalog loading
+# ---------------------------------------------------------------------------
+
+
+def _load_catalog(path: Path) -> list[dict]:
+    """Parse the TAB-separated bug catalog into a list of entry dicts.
+
+    Columns: ``bug_id  path  line  category  function  note`` (note optional,
+    line may be ``0`` for "unknown — match by function/category").
+    """
+    entries: list[dict] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return entries
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        parts = raw.split("\t")
+        if len(parts) < 5:
+            continue
+        bug_id, rel_path, line_s, category, function = (p.strip() for p in parts[:5])
+        note = "\t".join(parts[5:]).strip() if len(parts) > 5 else ""
+        try:
+            line = int(line_s)
+        except ValueError:
+            line = 0
+        entries.append(
+            {
+                "bug_id": bug_id,
+                "path": rel_path,
+                "line": line,
+                "category": category,
+                "function": function,
+                "note": note,
+            }
+        )
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Single-file scanning
+# ---------------------------------------------------------------------------
+
+
+def _scan_file(scanner, abs_file: Path, max_files: int) -> list[dict]:
+    """Run ``scanner`` over exactly one file, returning its findings.
+
+    The scanners resolve a *file* target to its parent directory (via
+    ``resolve_roots`` or an inline equivalent), so ``analyze(<file>)`` would
+    scan the whole directory — and a small ``--max-files`` could truncate
+    before reaching the target file. We instead patch the module-global
+    ``discover_c_files`` for the duration of the call so the scan iterates
+    exactly this one file. Project-root detection (hence the relative finding
+    paths we match on) still works, because we pass the absolute file path as
+    the target and the scanner walks up to the CPython root itself.
+    """
+
+    def _one_file(_root, *, max_files: int = 0):
+        yield abs_file
+
+    original = scanner.discover_c_files
+    scanner.discover_c_files = _one_file
+    try:
+        report = scanner.analyze(str(abs_file), max_files=max_files)
+    finally:
+        scanner.discover_c_files = original
+    return report.get("findings", [])
+
+
+def _index_findings(findings: list[dict], rel_file: str) -> dict:
+    """Index a file's findings by line-set and by enclosing function."""
+    lines: set[int] = set()
+    by_function: dict[str, list[int]] = defaultdict(list)
+    for f in findings:
+        if f.get("file") != rel_file:
+            continue  # defensive: only this file's findings
+        line = int(f.get("line", 0) or 0)
+        lines.add(line)
+        by_function[f.get("function", "")].append(line)
+    return {"lines": lines, "by_function": dict(by_function)}
+
+
+def _classify(entry: dict, index: dict) -> tuple[str, int | None]:
+    """Return ``(status, matched_line)`` for a scanned catalog entry."""
+    lines: set[int] = index["lines"]
+    by_function: dict[str, list[int]] = index["by_function"]
+    if not lines:
+        return "absent", None
+
+    func = entry["function"]
+    func_hits = by_function.get(func) if func and func != "0" else None
+    cat_line = entry["line"]
+
+    if cat_line > 0:
+        nearest = min(lines, key=lambda ln: abs(ln - cat_line))
+        if any(abs(ln - cat_line) <= _DRIFT for ln in lines):
+            return "present", nearest
+        if func_hits:
+            return "present", min(func_hits)
+        return "line_drifted", nearest
+
+    # Catalog line unknown: match by function name when we have one.
+    if func and func != "0":
+        if func_hits:
+            return "present", min(func_hits)
+        return "line_drifted", min(lines)
+    # No line and no function: any finding of the category counts as present.
+    return "present", min(lines)
+
+
+# ---------------------------------------------------------------------------
+# Analysis entry point
+# ---------------------------------------------------------------------------
+
+
+def analyze(
+    target: str,
+    *,
+    max_files: int = 0,
+    catalog_path: str | None = None,
+) -> dict:
+    """Cross-reference the known-crash catalog against a fresh scan of target."""
+    project_root, scan_root = resolve_roots(target)
+    catalog_file = Path(catalog_path) if catalog_path else _DEFAULT_CATALOG
+    catalog = _load_catalog(catalog_file)
+
+    # Cache one index per (category, rel_file) so multi-site bugs and repeated
+    # files scan each file at most once per scanner.
+    index_cache: dict[tuple[str, str], dict] = {}
+    scanned_files: set[str] = set()
+
+    results: list[dict] = []
+    findings: list[dict] = []
+    status_counts: dict[str, int] = {
+        "present": 0,
+        "line_drifted": 0,
+        "absent": 0,
+        "file_missing": 0,
+        "no_scanner": 0,
+    }
+    per_bug: dict[str, list[str]] = defaultdict(list)
+
+    for entry in catalog:
+        category = entry["category"]
+        rel_file = entry["path"]
+        scanner = CATEGORY_SCANNERS.get(category)
+        matched_line: int | None = None
+
+        if scanner is None:
+            status = "no_scanner"
+        else:
+            abs_file = project_root / rel_file
+            if not abs_file.is_file():
+                status = "file_missing"
+            else:
+                key = (category, rel_file)
+                if key not in index_cache:
+                    scan_findings = _scan_file(scanner, abs_file, max_files)
+                    index_cache[key] = _index_findings(scan_findings, rel_file)
+                    scanned_files.add(rel_file)
+                status, matched_line = _classify(entry, index_cache[key])
+
+        status_counts[status] += 1
+        per_bug[entry["bug_id"]].append(status)
+
+        results.append(
+            {
+                "bug_id": entry["bug_id"],
+                "path": rel_file,
+                "catalog_line": entry["line"],
+                "category": category,
+                "function": entry["function"],
+                "note": entry["note"],
+                "status": status,
+                "nearest_line": matched_line,
+                "scanner": getattr(scanner, "__name__", None),
+            }
+        )
+
+        if status in ("present", "line_drifted"):
+            confidence = "high" if status == "present" else "medium"
+            where = (
+                f"'{entry['function']}'"
+                if entry["function"] not in ("", "0")
+                else rel_file
+            )
+            if status == "present":
+                detail = (
+                    f"{entry['bug_id']}: known {category} bug in {where} ({rel_file}) "
+                    "is still present in a fresh scan — a previously-confirmed CPython "
+                    "crash site. Treat as a regression signal and read the file."
+                )
+            else:
+                detail = (
+                    f"{entry['bug_id']}: known {category} bug in {where} ({rel_file}) — "
+                    f"catalog site drifted; the file still has {category} findings, "
+                    f"nearest at line {matched_line}. The bug likely just moved; verify."
+                )
+            findings.append(
+                {
+                    "type": "known_bug_present"
+                    if status == "present"
+                    else "known_bug_line_drifted",
+                    "file": rel_file,
+                    "function": entry["function"],
+                    "line": matched_line or entry["line"] or 0,
+                    "confidence": confidence,
+                    "detail": detail,
+                    "bug_id": entry["bug_id"],
+                    "category": category,
+                    "status": status,
+                    "catalog_line": entry["line"],
+                    "nearest_line": matched_line,
+                    "note": entry["note"],
+                }
+            )
+
+    # Per-bug rollup: a bug is only "likely_fixed" if none of its sites is
+    # present or drifted and at least one scanned/known site is clean or gone.
+    bug_rollup: dict[str, str] = {}
+    for bug_id, statuses in per_bug.items():
+        s = set(statuses)
+        if "present" in s:
+            bug_rollup[bug_id] = "present"
+        elif "line_drifted" in s:
+            bug_rollup[bug_id] = "line_drifted"
+        elif s & {"absent", "file_missing"}:
+            bug_rollup[bug_id] = "likely_fixed"
+        else:
+            bug_rollup[bug_id] = "no_scanner"
+
+    rollup_counts: dict[str, int] = defaultdict(int)
+    for verdict in bug_rollup.values():
+        rollup_counts[verdict] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=len(scanned_files),
+        functions_analyzed=len(catalog),
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "still_present": status_counts["present"],
+            "line_drifted": status_counts["line_drifted"],
+            "no_scanner": status_counts["no_scanner"],
+            "by_status": dict(status_counts),
+        },
+        catalog_summary={
+            "catalog_path": str(catalog_file),
+            "catalog_entries": len(catalog),
+            "distinct_bugs": len(per_bug),
+            "files_scanned": len(scanned_files),
+            "status_counts": dict(status_counts),
+            "rollup_counts": dict(rollup_counts),
+        },
+        bug_rollup=dict(sorted(bug_rollup.items())),
+        catalog_results=results,
+        notes=[_ABSENCE_CAVEAT, _NO_SCANNER_CAVEAT],
+    )
+
+
+def main() -> None:
+    try:
+        argv = sys.argv[1:]
+        catalog_override: str | None = None
+        filtered: list[str] = []
+        i = 0
+        while i < len(argv):
+            if argv[i] == "--catalog" and i + 1 < len(argv):
+                catalog_override = argv[i + 1]
+                i += 2
+                continue
+            filtered.append(argv[i])
+            i += 1
+        target, max_files = parse_common_args(filtered)
+        result = analyze(target, max_files=max_files, catalog_path=catalog_override)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001 -- top-level guard, emit JSON error
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_common.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_common.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Shared utilities for cpython-review-toolkit analysis scripts.
+
+Provides common infrastructure used by the tree-sitter-based scanners:
+CPython root detection, C file discovery, CLI argument parsing, comment-based
+suppression, and finding deduplication.
+
+The generic helpers here are kept structurally in sync with the sibling
+toolkits' ``scan_common.py`` (cext / ft) so shared fixes propagate; the
+CPython-specific piece is :func:`find_cpython_root`, which keys off the
+CPython source-tree markers rather than a ``.git`` / ``pyproject.toml`` root.
+"""
+
+import json
+import re
+import sys
+from collections.abc import Generator
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tree_sitter_utils import (
+    C_EXTENSIONS,
+    get_node_text,
+)
+
+EXCLUDE_DIRS = frozenset(
+    {
+        ".git",
+        ".tox",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "node_modules",
+        "build",
+        "dist",
+        ".eggs",
+        "egg-info",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# CPython root detection + file discovery
+# ---------------------------------------------------------------------------
+
+
+def find_cpython_root(start: Path) -> Path | None:
+    """Walk up from ``start`` to the CPython source-tree root.
+
+    A CPython checkout is identified by the co-presence of ``Include/Python.h``
+    and ``Objects/object.c``. Returns None if no such root is found within 20
+    parent levels (callers fall back to the scan directory).
+    """
+    current = start if start.is_dir() else start.parent
+    for _ in range(20):
+        if (current / "Include" / "Python.h").is_file() and (
+            current / "Objects" / "object.c"
+        ).is_file():
+            return current
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def resolve_roots(target: str) -> tuple[Path, Path]:
+    """Return ``(project_root, scan_root)`` for a target path.
+
+    ``project_root`` is the CPython root if one is found (so finding paths are
+    reported relative to the checkout root, e.g. ``Objects/tupleobject.c``);
+    otherwise it falls back to the scan directory. ``scan_root`` is the
+    directory actually walked for ``.c`` / ``.h`` files.
+    """
+    target_path = Path(target).resolve()
+    scan_root = target_path if target_path.is_dir() else target_path.parent
+    project_root = find_cpython_root(target_path) or scan_root
+    return project_root, scan_root
+
+
+def relpath(filepath: Path, project_root: Path) -> str:
+    """Best-effort path of ``filepath`` relative to ``project_root``."""
+    try:
+        return str(filepath.relative_to(project_root))
+    except ValueError:
+        return str(filepath)
+
+
+def discover_c_files(
+    root: Path,
+    *,
+    max_files: int = 0,
+) -> Generator[Path, None, None]:
+    """Yield C source/header files under ``root``, skipping build dirs."""
+    count = 0
+    if root.is_file():
+        if root.suffix in C_EXTENSIONS:
+            yield root
+        return
+    for p in sorted(root.rglob("*")):
+        if not p.is_file() or p.suffix not in C_EXTENSIONS:
+            continue
+        try:
+            parts = set(p.relative_to(root).parts)
+        except ValueError:
+            continue
+        if parts & EXCLUDE_DIRS:
+            continue
+        yield p
+        count += 1
+        if max_files and count >= max_files:
+            return
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_common_args(argv: list[str]) -> tuple[str, int]:
+    """Parse common CLI arguments (positional path and ``--max-files N``).
+
+    Returns ``(target_path, max_files)``. ``max_files == 0`` means unlimited.
+    """
+    max_files = 0
+    positional: list[str] = []
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--max-files" and i + 1 < len(argv):
+            try:
+                max_files = int(argv[i + 1])
+            except ValueError:
+                print(
+                    json.dumps(
+                        {
+                            "error": (
+                                f"--max-files requires an integer, got '{argv[i + 1]}'"
+                            )
+                        }
+                    )
+                )
+                sys.exit(2)
+            i += 2
+        elif argv[i].startswith("--"):
+            i += 1
+        else:
+            positional.append(argv[i])
+            i += 1
+    target = positional[0] if positional else "."
+    return target, max_files
+
+
+# ---------------------------------------------------------------------------
+# Report envelope
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    *,
+    project_root: Path,
+    scan_root: Path,
+    files_analyzed: int,
+    functions_analyzed: int,
+    findings: list[dict],
+    summary: dict,
+    **extra: object,
+) -> dict:
+    """Assemble the standard JSON report envelope shared across scanners."""
+    report: dict = {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "files_analyzed": files_analyzed,
+        "functions_analyzed": functions_analyzed,
+        "findings": findings,
+        "summary": summary,
+    }
+    report.update(extra)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Comment-based suppression (parity with cext/ft scan_common)
+# ---------------------------------------------------------------------------
+
+_SAFETY_KEYWORDS = frozenset(
+    {
+        "safety:",
+        "safe because",
+        "intentional",
+        "by design",
+        "cpython-safe:",
+        "nolint",
+        "checked:",
+        "correct because",
+        "this is safe",
+        "not a bug",
+        "deliberately",
+        "already checked",
+        "gil held",
+        "gil-held",
+        "cannot fail",
+        "can't fail",
+    }
+)
+
+
+def extract_nearby_comments(
+    source_bytes: bytes, tree, line: int, radius: int = 5
+) -> list[str]:
+    """Return comment texts within ±``radius`` lines of a 1-indexed ``line``."""
+    comments: list[str] = []
+    min_line = max(0, line - radius - 1)  # 0-indexed
+    max_line = line + radius - 1
+
+    def _walk(node) -> None:
+        if node.type == "comment":
+            node_line = node.start_point[0]
+            if min_line <= node_line <= max_line:
+                comments.append(get_node_text(node, source_bytes))
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    return comments
+
+
+def has_safety_annotation(comments: list[str]) -> bool:
+    """True if any comment carries a human safety/suppression annotation."""
+    for comment in comments:
+        lower = comment.lower()
+        if any(kw in lower for kw in _SAFETY_KEYWORDS):
+            return True
+    return False
+
+
+def is_suppressed_by_comment(
+    source_bytes: bytes, tree, line: int, radius: int = 3
+) -> bool:
+    """True if a finding at ``line`` is annotated as intentional nearby."""
+    return has_safety_annotation(
+        extract_nearby_comments(source_bytes, tree, line, radius)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding deduplication (parity with cext scan_common)
+# ---------------------------------------------------------------------------
+
+
+def deduplicate_findings(findings: list[dict]) -> list[dict]:
+    """Collapse near-identical findings by (type, file, normalized detail).
+
+    Keeps the first occurrence as canonical and records the rest under
+    ``duplicate_count`` / ``duplicate_locations`` — useful when a systemic
+    pattern (e.g. a copy-pasted slot) repeats across many sites.
+    """
+
+    def _normalize_detail(detail: str) -> str:
+        text = re.sub(r"line \d+", "line N", detail)
+        text = re.sub(r"'[^']+?'", "'VAR'", text)
+        return text
+
+    groups: dict[tuple[str, str, str], list[dict]] = {}
+    for f in findings:
+        key = (
+            f.get("type", ""),
+            f.get("file", ""),
+            _normalize_detail(f.get("detail", "")),
+        )
+        groups.setdefault(key, []).append(f)
+
+    result: list[dict] = []
+    for group in groups.values():
+        canonical = group[0]
+        if len(group) > 1:
+            canonical["duplicate_count"] = len(group) - 1
+            canonical["duplicate_locations"] = [
+                {"file": d.get("file", ""), "line": d.get("line", 0)} for d in group[1:]
+            ]
+        result.append(canonical)
+    return result

--- a/plugins/cpython-review-toolkit/scripts/scan_pyerr_clear.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_pyerr_clear.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for exception-clobbering in the destructor family.
+
+The dangerous pattern (OOM class O3): a ``PyErr_Clear()`` inside a
+``tp_dealloc`` / ``tp_clear`` / ``tp_finalize`` / ``tp_traverse`` function with
+no surrounding save/restore of the exception state. Destructors and finalizers
+run while an exception may already be in flight (an object's last reference is
+commonly dropped mid-exception-handling), so an unguarded ``PyErr_Clear()``
+there silently swallows the caller's live ``MemoryError`` / ``KeyboardInterrupt``
+/ ``SystemExit``.
+
+The correct idiom brackets the risky work with a save/restore pair
+(``PyErr_GetRaisedException`` / ``PyErr_SetRaisedException``, the older
+``PyErr_Fetch`` / ``PyErr_Restore``, or reports via ``PyErr_WriteUnraisable``);
+functions that do so are treated as guarded and suppressed.
+
+Confirmed exemplars this targets: ``context_tp_dealloc`` (Modules/_contextvars,
+gh-152083), ``subtype_dealloc`` (Objects/typeobject.c), ``deque_clear``
+(Modules/_collectionsmodule.c).
+
+Usage:
+    python scan_pyerr_clear.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    get_node_text,
+    parse_bytes,
+    walk_descendants,
+)
+
+# Function-name suffixes that identify the destructor / GC family. The slot
+# kind carried alongside is used to weight severity (a swallow in dealloc/
+# finalize/clear is worse than in traverse, which should be side-effect-free
+# anyway — a PyErr_Clear there is unusual but worth surfacing).
+_DESTRUCTOR_SUFFIXES: tuple[tuple[str, str], ...] = (
+    ("_dealloc", "tp_dealloc"),
+    ("_finalize", "tp_finalize"),
+    ("_clear", "tp_clear"),
+    ("_traverse", "tp_traverse"),
+)
+
+# Exact names that don't follow the suffix convention.
+_DESTRUCTOR_EXACT = {
+    "subtype_dealloc": "tp_dealloc",
+    "dealloc": "tp_dealloc",
+}
+
+# Slot assignments in a static PyTypeObject / PyType_Slot table map a function
+# to a destructor slot even when its name doesn't advertise the role.
+_SLOT_DESIGNATED_RE = re.compile(
+    r"\.tp_(dealloc|finalize|clear|traverse)\s*=\s*(?:\(\s*\w[\w\s\*]*\)\s*)?"
+    r"(?:&\s*)?(\w+)"
+)
+_SLOT_SPEC_RE = re.compile(
+    r"\{\s*Py_tp_(dealloc|finalize|clear|traverse)\s*,\s*(?:&\s*)?(\w+)\s*\}"
+)
+
+# The presence of any of these in the function body means the author is
+# managing the exception state deliberately — suppress.
+_SAVE_RESTORE_APIS = frozenset(
+    {
+        "PyErr_Fetch",
+        "PyErr_Restore",
+        "PyErr_GetRaisedException",
+        "PyErr_SetRaisedException",
+        "PyErr_GetHandledException",
+        "PyErr_SetHandledException",
+        "PyErr_WriteUnraisable",
+        "_PyErr_WriteUnraisableMsg",
+        "_PyErr_ChainExceptions",
+        "_PyErr_ChainExceptions1",
+        "PyErr_FormatUnraisable",
+    }
+)
+
+
+def _collect_destructor_slot_map(source: str) -> dict[str, str]:
+    """Map function name -> destructor slot kind from static type tables."""
+    slot_map: dict[str, str] = {}
+    for slot, name in _SLOT_DESIGNATED_RE.findall(source):
+        slot_map[name] = f"tp_{slot}"
+    for slot, name in _SLOT_SPEC_RE.findall(source):
+        slot_map[name] = f"tp_{slot}"
+    return slot_map
+
+
+def _destructor_kind(func_name: str, slot_map: dict[str, str]) -> str | None:
+    """Return the destructor slot kind for a function, or None."""
+    if func_name in slot_map:
+        return slot_map[func_name]
+    if func_name in _DESTRUCTOR_EXACT:
+        return _DESTRUCTOR_EXACT[func_name]
+    for suffix, kind in _DESTRUCTOR_SUFFIXES:
+        if func_name.endswith(suffix):
+            return kind
+    return None
+
+
+def _find_pyerr_clear_calls(func: dict, source_bytes: bytes) -> list[dict]:
+    """Find every ``PyErr_Clear()`` call in a function body."""
+    calls: list[dict] = []
+    for node in walk_descendants(func["body_node"], type_filter="call_expression"):
+        fn_node = node.child_by_field_name("function")
+        if fn_node and get_node_text(fn_node, source_bytes) == "PyErr_Clear":
+            calls.append({"node": node, "line": node.start_point[0] + 1})
+    return calls
+
+
+def _has_save_restore_guard(func: dict) -> bool:
+    """True if the function manages exception state via a save/restore API."""
+    body = func["body"]
+    return any(api in body for api in _SAVE_RESTORE_APIS)
+
+
+def _check_function(func: dict, kind: str, source_bytes: bytes, tree) -> list[dict]:
+    """Flag unguarded ``PyErr_Clear()`` in a destructor-family function."""
+    clears = _find_pyerr_clear_calls(func, source_bytes)
+    if not clears:
+        return []
+    if _has_save_restore_guard(func):
+        return []
+
+    findings: list[dict] = []
+    # dealloc/finalize/clear run during teardown that may be mid-exception;
+    # traverse is meant to be side-effect-free, so a clear there is odd but
+    # lower-severity.
+    confidence = "medium" if kind == "tp_traverse" else "high"
+    for call in clears:
+        if is_suppressed_by_comment(source_bytes, tree, call["line"]):
+            continue
+        findings.append(
+            {
+                "type": "pyerr_clear_in_dealloc",
+                "function": func["name"],
+                "slot": kind,
+                "line": call["line"],
+                "confidence": confidence,
+                "detail": (
+                    f"PyErr_Clear() in {kind} function '{func['name']}' with no "
+                    "surrounding save/restore of the exception state — silently "
+                    "swallows an in-flight MemoryError / KeyboardInterrupt / "
+                    "SystemExit. Bracket the risky work with "
+                    "PyErr_GetRaisedException()/PyErr_SetRaisedException() (or "
+                    "report via PyErr_WriteUnraisable)."
+                ),
+            }
+        )
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for exception-clobbering PyErr_Clear() in the destructor family."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    total_functions = 0
+    total_clears = 0
+    destructor_functions = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        rel = relpath(filepath, project_root)
+        source = source_bytes.decode("utf-8", errors="replace")
+        slot_map = _collect_destructor_slot_map(source)
+
+        for func in functions:
+            total_functions += 1
+            kind = _destructor_kind(func["name"], slot_map)
+            if kind is None:
+                continue
+            destructor_functions += 1
+            clears = _find_pyerr_clear_calls(func, source_bytes)
+            total_clears += len(clears)
+            for f in _check_function(func, kind, source_bytes, tree):
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_confidence: dict[str, int] = defaultdict(int)
+    by_slot: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_confidence[f["confidence"]] += 1
+        by_slot[f["slot"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_confidence": dict(by_confidence),
+            "by_slot": dict(by_slot),
+        },
+        destructor_functions=destructor_functions,
+        total_pyerr_clear_calls_in_destructors=total_clears,
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # pragma: no cover - defensive
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_recursion_guards.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_recursion_guards.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for recursion-prone slots that lack a recursion guard.
+
+The dangerous pattern (bug class A / R1): a function wired to a recursion-prone
+type slot — ``tp_hash`` / ``tp_richcompare`` / ``tp_repr`` / ``tp_str`` — or a
+container parameter walk (``*make_parameters*`` / ``*subs_parameters*``) that
+descends into a Python object graph *without* ``Py_EnterRecursiveCall`` /
+``Py_ReprEnter``. A deeply-nested or cyclic object then overflows the **C
+stack** (SIGSEGV) instead of raising ``RecursionError``.
+
+Two descent shapes are detected:
+
+* **self-recursion** — the function calls itself with no guard (the
+  ``_Py_make_parameters`` class, gh-154275).
+* **container element-descent** — the function loops over a container and calls
+  a recursion-prone element op (``PyObject_Hash`` / ``PyObject_Repr`` /
+  ``PyObject_RichCompare`` …) with no guard (the ``tuple_hash`` /
+  ``frozendict_hash`` class, gh-154318 — noted upstream as a copy-pasted
+  guardless algorithm).
+
+The presence of any recursion-guard macro in the body suppresses the finding.
+
+Usage:
+    python scan_recursion_guards.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    find_calls_in_scope,
+    parse_bytes,
+    walk_descendants,
+)
+
+# Map a function name -> slot from static type tables (designated + spec form).
+# Recursion-prone slots (tp_hash / tp_richcompare / tp_repr / tp_str) descend
+# the object graph on user-controlled input.
+_SLOT_DESIGNATED_RE = re.compile(
+    r"\.tp_(hash|richcompare|repr|str)\s*=\s*(?:\(\s*\w[\w\s\*]*\)\s*)?"
+    r"(?:&\s*)?(\w+)"
+)
+_SLOT_SPEC_RE = re.compile(
+    r"\{\s*Py_tp_(hash|richcompare|repr|str)\s*,\s*(?:&\s*)?(\w+)\s*\}"
+)
+
+# Name-suffix heuristics for the same slots (many CPython slots are named
+# <type>_hash / <type>_repr / ... and never appear in a designated init).
+_SLOT_NAME_SUFFIX: tuple[tuple[str, str], ...] = (
+    ("_richcompare", "tp_richcompare"),
+    ("_hash", "tp_hash"),
+    ("_repr", "tp_repr"),
+    ("_str", "tp_str"),
+)
+
+# The parameter-walk class (PEP 585 generic alias): recurses over nested
+# type arguments; not a slot, but the same native-stack-overflow shape.
+_PARAM_WALK_RE = re.compile(r"(?:make|subs)_parameters", re.IGNORECASE)
+
+# Element operations that recurse back into the object graph. A container slot
+# that calls one of these on its items is descending element-wise.
+_ELEMENT_RECURSION_APIS = frozenset(
+    {
+        "PyObject_Hash",
+        "PyObject_Repr",
+        "PyObject_Str",
+        "PyObject_ASCII",
+        "PyObject_RichCompare",
+        "PyObject_RichCompareBool",
+    }
+)
+
+# Container-iteration signals (used with element ops to distinguish a
+# per-element descent from a single bounded attribute access).
+_CONTAINER_ACCESS_RE = re.compile(
+    r"\b\w*_GET_ITEM\b|\b\w*_GET_SIZE\b|\bPySequence_Fast_GET_ITEM\b"
+)
+
+# Recursion-guard macros. Any of these in the body discharges the obligation.
+_GUARD_TOKENS = frozenset(
+    {
+        "Py_EnterRecursiveCall",
+        "_Py_EnterRecursiveCall",
+        "Py_EnterRecursiveCallTstate",
+        "_Py_EnterRecursiveCallTstate",
+        "Py_ReprEnter",
+        "Py_ReprLeave",
+    }
+)
+
+
+def _collect_slot_map(source: str) -> dict[str, str]:
+    slot_map: dict[str, str] = {}
+    for slot, name in _SLOT_DESIGNATED_RE.findall(source):
+        slot_map[name] = f"tp_{slot}"
+    for slot, name in _SLOT_SPEC_RE.findall(source):
+        slot_map[name] = f"tp_{slot}"
+    return slot_map
+
+
+def _slot_for(func_name: str, slot_map: dict[str, str]) -> str | None:
+    """Classify a function as a recursion-prone slot, else None."""
+    if func_name in slot_map:
+        return slot_map[func_name]
+    if _PARAM_WALK_RE.search(func_name):
+        return "parameter_walk"
+    for suffix, slot in _SLOT_NAME_SUFFIX:
+        if func_name.endswith(suffix):
+            return slot
+    return None
+
+
+def _has_guard(func: dict) -> bool:
+    body = func["body"]
+    return any(tok in body for tok in _GUARD_TOKENS)
+
+
+def _has_loop(body_node) -> bool:
+    for _ in walk_descendants(body_node, type_filter="for_statement"):
+        return True
+    for _ in walk_descendants(body_node, type_filter="while_statement"):
+        return True
+    for _ in walk_descendants(body_node, type_filter="do_statement"):
+        return True
+    return False
+
+
+def _analyze_function(func: dict, slot: str, source_bytes: bytes, tree) -> dict | None:
+    """Return a finding dict for an unguarded recursive slot, else None."""
+    if _has_guard(func):
+        return None
+
+    calls = find_calls_in_scope(func["body_node"], source_bytes)
+    call_names = {c["function_name"] for c in calls}
+
+    self_recursive = func["name"] in call_names
+    element_apis = call_names & _ELEMENT_RECURSION_APIS
+    has_container = bool(_CONTAINER_ACCESS_RE.search(func["body"])) or _has_loop(
+        func["body_node"]
+    )
+    element_descent = bool(element_apis) and has_container
+
+    if not (self_recursive or element_descent):
+        return None
+
+    # Locate a representative line: the first self-call or element op.
+    line = func["start_line"]
+    for c in calls:
+        if c["function_name"] == func["name"] or (
+            c["function_name"] in _ELEMENT_RECURSION_APIS and element_descent
+        ):
+            line = c["start_line"]
+            break
+
+    if is_suppressed_by_comment(source_bytes, tree, line):
+        return None
+
+    if self_recursive:
+        shape = "self_recursion"
+        confidence = "high"
+        why = (
+            f"'{func['name']}' recurses into itself with no Py_EnterRecursiveCall guard"
+        )
+    else:
+        shape = "container_element_descent"
+        # hash/richcompare container descent is the confirmed SIGSEGV class;
+        # repr/str often carry other bounds, so rate them a notch lower.
+        confidence = "high" if slot in ("tp_hash", "tp_richcompare") else "medium"
+        why = (
+            f"'{func['name']}' ({slot}) descends into container elements via "
+            f"{', '.join(sorted(element_apis))} with no Py_EnterRecursiveCall/"
+            "Py_ReprEnter guard"
+        )
+
+    return {
+        "type": "missing_recursion_guard",
+        "function": func["name"],
+        "slot": slot,
+        "shape": shape,
+        "line": line,
+        "confidence": confidence,
+        "detail": (
+            f"{why} — a deeply-nested or cyclic object overflows the C stack "
+            "(SIGSEGV) instead of raising RecursionError. Bracket the descent "
+            "with Py_EnterRecursiveCall()/Py_LeaveRecursiveCall() (or "
+            "Py_ReprEnter()/Py_ReprLeave() for repr/str)."
+        ),
+    }
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for recursion-prone slots lacking a recursion guard."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    total_functions = 0
+    slot_functions = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        rel = relpath(filepath, project_root)
+        source = source_bytes.decode("utf-8", errors="replace")
+        slot_map = _collect_slot_map(source)
+
+        for func in functions:
+            total_functions += 1
+            slot = _slot_for(func["name"], slot_map)
+            if slot is None:
+                continue
+            slot_functions += 1
+            f = _analyze_function(func, slot, source_bytes, tree)
+            if f is not None:
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_confidence: dict[str, int] = defaultdict(int)
+    by_shape: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_confidence[f["confidence"]] += 1
+        by_shape[f["shape"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_confidence": dict(by_confidence),
+            "by_shape": dict(by_shape),
+        },
+        recursion_prone_slot_functions=slot_functions,
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # pragma: no cover - defensive
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_uninit_dealloc.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_uninit_dealloc.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for dealloc of a half-constructed object on error.
+
+The dangerous pattern (bug class B / O5): a constructor allocates an object
+with a **non-zeroing** allocator (``PyObject_New`` / ``PyObject_GC_New`` /
+``PyObject_NewVar`` …), then — before initializing the object's pointer members
+to NULL — hits a fallible step and frees the object on the error path
+(``Py_DECREF`` / ``Py_XDECREF`` / ``Py_CLEAR``). The ``tp_dealloc`` / ``tp_clear``
+then reads those still-uninitialized members (garbage pointers) and crashes.
+Under out-of-memory this is the dominant reachable-from-Python crash surface.
+
+The correct idiom either zeroes the object right after allocation (``memset(op,
+0, ...)`` or a run of ``op->member = NULL;`` before the first fallible call) or
+uses a zeroing allocator (``tp_alloc`` / ``PyType_GenericAlloc`` /
+``*_GC_Calloc``). Constructors that do so are treated as safe.
+
+Confirmed exemplars: ``template_iter`` dealloc of an uninitialized member
+(Objects/templateobject.c, gh-151815), blake2 ``.copy()`` freeing an object
+with an uninitialized ``impl`` enum (Modules/blake2, gh-152851).
+
+Usage:
+    python scan_uninit_dealloc.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    find_assignments_in_scope,
+    parse_bytes,
+)
+
+# Allocators that do NOT zero the type-specific fields of the new object.
+_NON_ZEROING_ALLOCATORS = (
+    "PyObject_New",
+    "PyObject_NewVar",
+    "PyObject_GC_New",
+    "PyObject_GC_NewVar",
+    "_PyObject_New",
+    "_PyObject_NewVar",
+    "_PyObject_GC_New",
+    "_PyObject_GC_NewVar",
+    "PyObject_GC_NewWithExtra",
+)
+
+_NON_ZEROING_RE = re.compile(
+    r"^\s*(?:\(\s*[\w\s\*]+\)\s*)?(" + "|".join(_NON_ZEROING_ALLOCATORS) + r")\s*\("
+)
+
+
+def _member_null_init_re(var: str) -> re.Pattern:
+    return re.compile(rf"\b{re.escape(var)}\s*->\s*\w+\s*=\s*NULL")
+
+
+def _member_write_re(var: str) -> re.Pattern:
+    return re.compile(rf"\b{re.escape(var)}\s*->\s*\w+\s*=")
+
+
+def _memset_zero_re(var: str) -> re.Pattern:
+    return re.compile(
+        rf"memset\s*\(\s*(?:\(\s*void\s*\*\s*\)\s*)?{re.escape(var)}\b[^;]*,\s*0\s*,"
+    )
+
+
+def _early_free_re(var: str) -> re.Pattern:
+    return re.compile(rf"Py_(?:X?DECREF|CLEAR)\s*\(\s*{re.escape(var)}\b")
+
+
+def _check_function(func: dict, source_bytes: bytes, tree) -> list[dict]:
+    """Flag non-zeroing constructors that free the object before init."""
+    findings: list[dict] = []
+    body = func["body"]
+    body_start = func["body_node"].start_byte + 1  # +1: leading '{' stripped
+
+    for assign in find_assignments_in_scope(func["body_node"], source_bytes):
+        var = assign["variable"]
+        if not var.isidentifier():
+            continue
+        m = _NON_ZEROING_RE.match(assign["value_text"])
+        if not m:
+            continue
+        api = m.group(1)
+
+        offset = assign["value_node"].start_byte - body_start
+        if offset < 0 or offset > len(body):
+            continue
+        tail = body[offset:]
+
+        # Object explicitly zeroed after allocation -> safe.
+        if _memset_zero_re(var).search(tail):
+            continue
+        # Locate the first early free of the object on an error path. Without
+        # one, nothing is flagged (the only decref is the caller's, on the
+        # successfully returned object).
+        free_m = _early_free_re(var).search(tail)
+        if free_m is None:
+            continue
+        # The object must carry pointer members a dealloc would touch.
+        if not _member_write_re(var).search(tail):
+            continue
+        # Correct pattern: members NULL-initialized (or the object memset)
+        # before it is freed, so tp_dealloc sees NULL (Py_XDECREF(NULL) is
+        # safe) rather than garbage. The allocation's own `if (var == NULL)`
+        # guard doesn't free var, so this boundary is the real error path.
+        pre_free = tail[: free_m.start()]
+        if _member_null_init_re(var).search(pre_free):
+            continue
+
+        line = assign["start_line"]
+        if is_suppressed_by_comment(source_bytes, tree, line):
+            continue
+
+        findings.append(
+            {
+                "type": "dealloc_of_uninitialized_object",
+                "function": func["name"],
+                "variable": var,
+                "allocator": api,
+                "line": line,
+                "confidence": "medium",
+                "detail": (
+                    f"'{var}' is allocated via the non-zeroing {api}() and freed "
+                    f"on an error path (Py_DECREF/Py_XDECREF/Py_CLEAR) before its "
+                    f"members are NULL-initialized — tp_dealloc/tp_clear then "
+                    f"reads uninitialized member pointers (crash, esp. under "
+                    f"OOM). Zero the object right after allocation (memset or "
+                    f"`{var}->member = NULL;` before the first fallible call)."
+                ),
+            }
+        )
+
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for constructors that free half-initialized objects on error."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    total_functions = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        rel = relpath(filepath, project_root)
+
+        for func in functions:
+            total_functions += 1
+            for f in _check_function(func, source_bytes, tree):
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_allocator: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_allocator[f["allocator"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_allocator": dict(by_allocator),
+        },
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # pragma: no cover - defensive
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/tree_sitter_utils.py
+++ b/plugins/cpython-review-toolkit/scripts/tree_sitter_utils.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""Tree-sitter parsing utilities for C/C++ extension analysis.
+
+This is the core parsing module used by all analysis scripts in
+cext-review-toolkit. It provides structured access to C/C++ source code
+via Tree-sitter, replacing fragile regex-based parsing.
+
+Requires: pip install tree-sitter tree-sitter-c
+Optional: pip install tree-sitter-cpp (for C++ file support)
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tree_sitter
+    import tree_sitter_c
+except ImportError:
+    print(
+        json.dumps(
+            {
+                "error": "tree-sitter not installed",
+                "install": "pip install tree-sitter tree-sitter-c",
+            }
+        )
+    )
+    sys.exit(1)
+
+# Initialize the C parser once at module level.
+C_LANGUAGE = tree_sitter.Language(tree_sitter_c.language())
+_parser = tree_sitter.Parser(C_LANGUAGE)
+
+# C++ support (optional).
+_CPP_AVAILABLE = False
+_cpp_parser: tree_sitter.Parser | None = None
+
+try:
+    import tree_sitter_cpp
+
+    _CPP_AVAILABLE = True
+except ImportError:
+    pass
+
+C_EXTENSIONS = frozenset({".c", ".h"})
+CPP_EXTENSIONS = frozenset({".cpp", ".cxx", ".cc", ".hpp"})
+ALL_SOURCE_EXTENSIONS = C_EXTENSIONS | CPP_EXTENSIONS
+
+
+def is_cpp_available() -> bool:
+    """Check if tree-sitter-cpp is installed."""
+    return _CPP_AVAILABLE
+
+
+def _get_cpp_parser() -> tree_sitter.Parser:
+    """Lazily initialize and return the C++ parser."""
+    global _cpp_parser
+    if _cpp_parser is None:
+        if not _CPP_AVAILABLE:
+            raise ImportError(
+                "tree-sitter-cpp not installed: pip install tree-sitter-cpp"
+            )
+        cpp_language = tree_sitter.Language(tree_sitter_cpp.language())
+        _cpp_parser = tree_sitter.Parser(cpp_language)
+    return _cpp_parser
+
+
+def get_parser_for_file(filepath: Path) -> tree_sitter.Parser:
+    """Return the appropriate parser for a file based on its extension."""
+    if filepath.suffix in CPP_EXTENSIONS and _CPP_AVAILABLE:
+        return _get_cpp_parser()
+    return _parser
+
+
+def parse_bytes_for_file(source_bytes: bytes, filepath: Path) -> tree_sitter.Tree:
+    """Parse source bytes using the parser appropriate for the file type."""
+    parser = get_parser_for_file(filepath)
+    return parser.parse(source_bytes)
+
+
+def parse_file(path: Path) -> tree_sitter.Tree:
+    """Parse a C source file and return the Tree-sitter syntax tree."""
+    source_bytes = path.read_bytes()
+    return _parser.parse(source_bytes)
+
+
+def parse_string(source: str) -> tree_sitter.Tree:
+    """Parse a C source string and return the Tree-sitter syntax tree."""
+    return _parser.parse(source.encode("utf-8"))
+
+
+def parse_bytes(source_bytes: bytes) -> tree_sitter.Tree:
+    """Parse C source from bytes already in memory."""
+    return _parser.parse(source_bytes)
+
+
+def get_node_text(node: tree_sitter.Node, source_bytes: bytes) -> str:
+    """Get the source text for a tree-sitter node."""
+    return source_bytes[node.start_byte : node.end_byte].decode(
+        "utf-8", errors="replace"
+    )
+
+
+def walk_descendants(node: tree_sitter.Node, type_filter: str | None = None):
+    """Yield all descendant nodes, optionally filtered by node type.
+
+    Common type names: 'call_expression', 'return_statement',
+    'if_statement', 'goto_statement', 'declaration', 'assignment_expression',
+    'binary_expression', 'identifier', 'string_literal'
+    """
+    cursor = node.walk()
+    visited = False
+    while True:
+        if not visited:
+            current = cursor.node
+            if type_filter is None or current.type == type_filter:
+                yield current
+            if cursor.goto_first_child():
+                visited = False
+                continue
+        if cursor.goto_next_sibling():
+            visited = False
+            continue
+        if cursor.goto_parent():
+            visited = True
+            continue
+        break
+
+
+def get_declarator_name(node: tree_sitter.Node, source_bytes: bytes) -> str | None:
+    """Extract the identifier name from a declarator, handling pointers and arrays."""
+    if node.type in ("identifier", "field_identifier"):
+        return get_node_text(node, source_bytes)
+    if node.type == "pointer_declarator":
+        decl = node.child_by_field_name("declarator")
+        if decl:
+            return get_declarator_name(decl, source_bytes)
+    if node.type == "array_declarator":
+        decl = node.child_by_field_name("declarator")
+        if decl:
+            return get_declarator_name(decl, source_bytes)
+    if node.type == "parenthesized_declarator":
+        for child in node.children:
+            name = get_declarator_name(child, source_bytes)
+            if name:
+                return name
+    if node.type == "function_declarator":
+        decl = node.child_by_field_name("declarator")
+        if decl:
+            return get_declarator_name(decl, source_bytes)
+    for child in node.children:
+        if child.type in ("identifier", "field_identifier"):
+            return get_node_text(child, source_bytes)
+    return None
+
+
+def _get_function_declarator(node: tree_sitter.Node) -> tree_sitter.Node | None:
+    """Find the function_declarator within a declarator tree."""
+    if node.type == "function_declarator":
+        return node
+    for child in node.children:
+        result = _get_function_declarator(child)
+        if result:
+            return result
+    return None
+
+
+# Node types that WRAP function definitions rather than being them. When
+# collecting top-level definitions we descend into these so nested functions
+# are still found. The preproc_* entries matter for header-only C extensions:
+# an entire header body wrapped in an "#ifndef FOO_H ... #endif" include guard
+# parses as a single preproc_ifdef node, so a root-children-only walk would
+# find ZERO functions in it.
+_WRAPPER_NODE_TYPES = frozenset(
+    {
+        "linkage_specification",  # extern "C" { ... }
+        "namespace_definition",  # namespace X { ... }
+        "preproc_ifdef",  # #ifndef / #ifdef ... #endif  (include guards)
+        "preproc_if",  # #if ... #endif
+        "preproc_elif",  # #elif ...
+        "preproc_else",  # #else ...
+    }
+)
+
+
+def _collect_top_level_nodes(nodes: list) -> list:
+    """Flatten a node list, descending into extern-C / namespace / preprocessor
+    wrapper nodes so function definitions nested inside them are still found.
+
+    extern "C" and namespace hold their members under a ``body`` field;
+    preprocessor conditionals hold them as direct children. Recurses so nested
+    wrappers (e.g. an ``#if PY_VERSION_HEX`` inside an ``#ifndef`` guard) work.
+    """
+    result = []
+    for node in nodes:
+        if node.type in ("linkage_specification", "namespace_definition"):
+            body = node.child_by_field_name("body")
+            result.extend(
+                _collect_top_level_nodes(body.children if body else node.children)
+            )
+        elif node.type in _WRAPPER_NODE_TYPES:
+            result.extend(_collect_top_level_nodes(node.children))
+        else:
+            result.append(node)
+    return result
+
+
+def extract_functions(tree: tree_sitter.Tree, source_bytes: bytes) -> list[dict]:
+    """Extract all function definitions from a parse tree.
+
+    Returns list of dicts with keys:
+      - name: str (function name)
+      - return_type: str
+      - parameters: str (raw parameter text)
+      - body: str (function body text, excluding braces)
+      - body_node: tree_sitter.Node (the compound_statement node)
+      - start_line: int (1-indexed)
+      - end_line: int (1-indexed)
+      - start_byte: int
+      - end_byte: int
+    """
+    functions = []
+    root = tree.root_node
+
+    # Collect top-level nodes, descending into extern "C" {} / namespace {}
+    # blocks and #ifndef/#ifdef/#if include guards + conditionals, all of which
+    # wrap function definitions. Without the preproc descent, a header-only
+    # extension whose entire body sits inside an "#ifndef FOO_H" guard yields
+    # zero functions.
+    top_nodes = _collect_top_level_nodes(root.children)
+
+    for node in top_nodes:
+        if node.type != "function_definition":
+            continue
+
+        declarator = node.child_by_field_name("declarator")
+        body_node = node.child_by_field_name("body")
+        if not declarator or not body_node:
+            continue
+
+        # Get the return type: everything before the declarator.
+        return_type_parts = []
+        for child in node.children:
+            if child == declarator:
+                break
+            if child.type not in ("comment",):
+                return_type_parts.append(get_node_text(child, source_bytes))
+        return_type = " ".join(return_type_parts).strip()
+
+        # Find the function_declarator to get name and params.
+        func_decl = _get_function_declarator(declarator)
+        if not func_decl:
+            continue
+
+        name_node = func_decl.child_by_field_name("declarator")
+        params_node = func_decl.child_by_field_name("parameters")
+
+        if not name_node:
+            continue
+
+        func_name = get_declarator_name(name_node, source_bytes)
+        if not func_name:
+            continue
+
+        params_text = ""
+        if params_node:
+            params_text = get_node_text(params_node, source_bytes)
+            # Strip outer parentheses.
+            if params_text.startswith("(") and params_text.endswith(")"):
+                params_text = params_text[1:-1].strip()
+
+        # Body text: strip outer braces.
+        body_text = get_node_text(body_node, source_bytes)
+        if body_text.startswith("{") and body_text.endswith("}"):
+            body_text = body_text[1:-1]
+
+        functions.append(
+            {
+                "name": func_name,
+                "return_type": return_type,
+                "parameters": params_text,
+                "body": body_text,
+                "body_node": body_node,
+                "start_line": node.start_point[0] + 1,
+                "end_line": node.end_point[0] + 1,
+                "start_byte": node.start_byte,
+                "end_byte": node.end_byte,
+            }
+        )
+
+    return functions
+
+
+def extract_struct_initializers(
+    tree: tree_sitter.Tree, source_bytes: bytes, type_name: str
+) -> list[dict]:
+    """Find static struct initializers for a given type name.
+
+    e.g., extract_struct_initializers(tree, source, "PyMethodDef") finds:
+      static PyMethodDef module_methods[] = { ... };
+
+    Returns list of dicts with keys:
+      - variable_name: str
+      - type_name: str
+      - is_array: bool
+      - initializer_text: str (the { ... } content)
+      - initializer_node: tree_sitter.Node
+      - start_line: int
+      - end_line: int
+    """
+    results = []
+    root = tree.root_node
+
+    for node in root.children:
+        if node.type != "declaration":
+            continue
+
+        decl_text = get_node_text(node, source_bytes)
+        # Check if the type name appears in the declaration.
+        if type_name not in decl_text:
+            continue
+
+        # Look for the type specifier.
+        type_node = node.child_by_field_name("type")
+        if type_node:
+            type_text = get_node_text(type_node, source_bytes)
+            if type_name not in type_text:
+                # Also check if it's "struct type_name"
+                found = False
+                for desc in walk_descendants(type_node):
+                    if (
+                        desc.type == "type_identifier"
+                        and get_node_text(desc, source_bytes) == type_name
+                    ):
+                        found = True
+                        break
+                if not found:
+                    continue
+
+        # Find init_declarator children to get variable name and initializer.
+        for child in node.children:
+            if child.type != "init_declarator":
+                continue
+
+            declarator = child.child_by_field_name("declarator")
+            value = child.child_by_field_name("value")
+            if not declarator or not value:
+                continue
+
+            var_name = get_declarator_name(declarator, source_bytes)
+            if not var_name:
+                continue
+
+            is_array = "array_declarator" in get_node_text(
+                declarator, source_bytes
+            ) or "[" in get_node_text(declarator, source_bytes)
+
+            init_text = get_node_text(value, source_bytes)
+
+            results.append(
+                {
+                    "variable_name": var_name,
+                    "type_name": type_name,
+                    "is_array": is_array,
+                    "initializer_text": init_text,
+                    "initializer_node": value,
+                    "start_line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                }
+            )
+
+    return results
+
+
+def extract_static_declarations(
+    tree: tree_sitter.Tree, source_bytes: bytes
+) -> list[dict]:
+    """Find all file-scope static variable declarations.
+
+    Returns list of dicts with keys:
+      - name: str (variable name)
+      - type: str (full type including qualifiers, e.g., "static PyObject *")
+      - is_const: bool
+      - is_pointer: bool
+      - is_pyobject: bool (type contains "PyObject")
+      - initializer: str | None
+      - start_line: int
+    """
+    results = []
+    root = tree.root_node
+
+    for node in root.children:
+        if node.type != "declaration":
+            continue
+
+        decl_text = get_node_text(node, source_bytes)
+        # Must be static.
+        if not decl_text.lstrip().startswith("static"):
+            has_static = False
+            for child in node.children:
+                if (
+                    child.type == "storage_class_specifier"
+                    and get_node_text(child, source_bytes) == "static"
+                ):
+                    has_static = True
+                    break
+            if not has_static:
+                continue
+
+        # Skip function declarations (those have function_declarator).
+        is_func_decl = False
+        for desc in walk_descendants(node, "function_declarator"):
+            is_func_decl = True
+            break
+        if is_func_decl:
+            continue
+
+        # Get type info.
+        is_const = "const" in decl_text.split("=")[0]
+
+        # Find each declared variable.
+        for child in node.children:
+            if child.type == "init_declarator":
+                declarator = child.child_by_field_name("declarator")
+                value = child.child_by_field_name("value")
+                if not declarator:
+                    continue
+                var_name = get_declarator_name(declarator, source_bytes)
+                if not var_name:
+                    continue
+                decl_part = decl_text.split("=")[0].strip().rstrip(";").strip()
+                is_pointer = "*" in decl_part
+                is_pyobject = "PyObject" in decl_part
+                init_text = get_node_text(value, source_bytes) if value else None
+                results.append(
+                    {
+                        "name": var_name,
+                        "type": decl_part.rsplit(var_name, 1)[0].strip()
+                        if var_name in decl_part
+                        else decl_part,
+                        "is_const": is_const,
+                        "is_pointer": is_pointer,
+                        "is_pyobject": is_pyobject,
+                        "initializer": init_text,
+                        "start_line": node.start_point[0] + 1,
+                    }
+                )
+            elif child.type in ("identifier", "pointer_declarator", "array_declarator"):
+                # Declaration without initializer.
+                var_name = get_declarator_name(child, source_bytes)
+                if not var_name:
+                    continue
+                decl_part = decl_text.strip().rstrip(";").strip()
+                is_pointer = "*" in decl_part
+                is_pyobject = "PyObject" in decl_part
+                results.append(
+                    {
+                        "name": var_name,
+                        "type": decl_part.rsplit(var_name, 1)[0].strip()
+                        if var_name in decl_part
+                        else decl_part,
+                        "is_const": is_const,
+                        "is_pointer": is_pointer,
+                        "is_pyobject": is_pyobject,
+                        "initializer": None,
+                        "start_line": node.start_point[0] + 1,
+                    }
+                )
+
+    return results
+
+
+def find_calls_in_scope(
+    node: tree_sitter.Node, source_bytes: bytes, api_names: set[str] | None = None
+) -> list[dict]:
+    """Find all function calls within a given AST node (typically a function body).
+
+    If api_names is provided, only return calls to those functions.
+
+    Returns list of dicts with keys:
+      - function_name: str
+      - arguments_text: str
+      - node: tree_sitter.Node
+      - start_line: int
+      - start_byte: int
+    """
+    results = []
+    for call_node in walk_descendants(node, "call_expression"):
+        func_node = call_node.child_by_field_name("function")
+        args_node = call_node.child_by_field_name("arguments")
+        if not func_node:
+            continue
+
+        func_name = get_node_text(func_node, source_bytes)
+        if api_names is not None and func_name not in api_names:
+            continue
+
+        args_text = ""
+        if args_node:
+            args_text = get_node_text(args_node, source_bytes)
+            if args_text.startswith("(") and args_text.endswith(")"):
+                args_text = args_text[1:-1].strip()
+
+        results.append(
+            {
+                "function_name": func_name,
+                "arguments_text": args_text,
+                "node": call_node,
+                "start_line": call_node.start_point[0] + 1,
+                "start_byte": call_node.start_byte,
+            }
+        )
+
+    return results
+
+
+def find_assignments_in_scope(
+    node: tree_sitter.Node, source_bytes: bytes, var_name: str | None = None
+) -> list[dict]:
+    """Find variable assignments within a scope.
+
+    If var_name is provided, only return assignments to that variable.
+
+    Returns list of dicts with keys:
+      - variable: str
+      - value_text: str
+      - value_node: tree_sitter.Node
+      - is_declaration: bool (part of a declaration vs standalone assignment)
+      - start_line: int
+    """
+    results = []
+
+    # Find standalone assignments (assignment_expression).
+    for assign_node in walk_descendants(node, "assignment_expression"):
+        left = assign_node.child_by_field_name("left")
+        right = assign_node.child_by_field_name("right")
+        if not left or not right:
+            continue
+        assigned_var = get_node_text(left, source_bytes)
+        if var_name is not None and assigned_var != var_name:
+            continue
+        results.append(
+            {
+                "variable": assigned_var,
+                "value_text": get_node_text(right, source_bytes),
+                "value_node": right,
+                "is_declaration": False,
+                "start_line": assign_node.start_point[0] + 1,
+            }
+        )
+
+    # Find declaration-initializations (init_declarator inside declarations).
+    for decl_node in walk_descendants(node, "init_declarator"):
+        declarator = decl_node.child_by_field_name("declarator")
+        value = decl_node.child_by_field_name("value")
+        if not declarator or not value:
+            continue
+        declared_var = get_declarator_name(declarator, source_bytes)
+        if not declared_var:
+            continue
+        if var_name is not None and declared_var != var_name:
+            continue
+        results.append(
+            {
+                "variable": declared_var,
+                "value_text": get_node_text(value, source_bytes),
+                "value_node": value,
+                "is_declaration": True,
+                "start_line": decl_node.start_point[0] + 1,
+            }
+        )
+
+    return results
+
+
+def find_return_statements(node: tree_sitter.Node, source_bytes: bytes) -> list[dict]:
+    """Find all return statements within a scope.
+
+    Returns list of dicts with keys:
+      - value_text: str | None (None for bare 'return;')
+      - node: tree_sitter.Node
+      - start_line: int
+    """
+    results = []
+    for ret_node in walk_descendants(node, "return_statement"):
+        # A return statement's children: 'return' keyword, optional expression, ';'
+        value_text = None
+        for child in ret_node.children:
+            if child.type not in ("return", ";", "comment"):
+                value_text = get_node_text(child, source_bytes)
+                break
+        results.append(
+            {
+                "value_text": value_text,
+                "node": ret_node,
+                "start_line": ret_node.start_point[0] + 1,
+            }
+        )
+    return results
+
+
+def find_struct_members(
+    tree: tree_sitter.Tree, source_bytes: bytes, struct_name: str
+) -> list[dict]:
+    """Find members of a named struct definition.
+
+    Returns list of dicts with keys:
+      - name: str
+      - type: str
+      - is_pyobject: bool
+      - start_line: int
+    """
+    results = []
+
+    # Look for struct definitions in type_definition or struct_specifier nodes.
+    for node in walk_descendants(tree.root_node, "struct_specifier"):
+        # Check if this struct has a name matching or a typedef name matching.
+        name_node = node.child_by_field_name("name")
+        struct_ident = get_node_text(name_node, source_bytes) if name_node else None
+
+        # Check if this struct is inside a typedef with the target name.
+        parent = node.parent
+        is_match = False
+        if struct_ident == struct_name:
+            is_match = True
+        elif parent and parent.type == "type_definition":
+            # Check the typedef name.
+            type_def_text = get_node_text(parent, source_bytes)
+            if struct_name in type_def_text:
+                # Find the declarator of the typedef.
+                for child in parent.children:
+                    if (
+                        child.type == "type_identifier"
+                        and get_node_text(child, source_bytes) == struct_name
+                    ):
+                        is_match = True
+                        break
+
+        if not is_match:
+            continue
+
+        # Find the field_declaration_list (body).
+        body = node.child_by_field_name("body")
+        if not body:
+            continue
+
+        for field in body.children:
+            if field.type != "field_declaration":
+                continue
+            # Find field name from the declarator.
+            declarator = field.child_by_field_name("declarator")
+            if not declarator:
+                continue
+            field_name = get_declarator_name(declarator, source_bytes)
+            if not field_name:
+                continue
+
+            # Get the type.
+            type_parts = []
+            for child in field.children:
+                if child == declarator or child.type == ";":
+                    break
+                type_parts.append(get_node_text(child, source_bytes))
+            field_type = " ".join(type_parts).strip()
+            if "*" in get_node_text(declarator, source_bytes):
+                field_type += " *"
+
+            is_pointer = "*" in field_type
+            is_pyobject = "PyObject" in field_type
+
+            results.append(
+                {
+                    "name": field_name,
+                    "type": field_type,
+                    "is_pyobject": is_pyobject,
+                    "is_pointer": is_pointer,
+                    "start_line": field.start_point[0] + 1,
+                }
+            )
+
+    return results
+
+
+def strip_comments(source: str) -> str:
+    """Remove C comments (/* */ and //) from source text.
+    Simpler than tree-sitter for cases where we just need clean text."""
+    # Remove block comments.
+    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.DOTALL)
+    # Remove line comments.
+    source = re.sub(r"//[^\n]*", " ", source)
+    return source

--- a/tests/test_build_informed_briefing.py
+++ b/tests/test_build_informed_briefing.py
@@ -1,0 +1,186 @@
+"""Tests for build_informed_briefing.py — the informed-explore briefing generator.
+
+The generator emits Markdown (not JSON) assembled from the CPython bug-shape
+catalog, the cross-cutting triage rules, the FP taxonomy, and — optionally — a
+``cpython-review-findings`` catalog dir. These tests use the real shipped
+catalogs for the default-path assertions and a ``tempfile`` fixture for the
+``--catalog-dir`` behavior.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from helpers import import_script
+
+_DATA = (
+    Path(__file__).resolve().parent.parent
+    / "plugins"
+    / "cpython-review-toolkit"
+    / "data"
+)
+
+
+class TestBuildInformedBriefing(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("build_informed_briefing")
+
+    def _shapes(self) -> list[dict]:
+        data = json.loads(
+            (_DATA / "cpython_bug_shapes.json").read_text(encoding="utf-8")
+        )
+        return data["shapes"]
+
+    # --- default briefing --------------------------------------------------
+
+    def test_briefing_has_a_section_for_each_shape_id(self):
+        briefing = self.mod.build_briefing()
+        for shape in self._shapes():
+            self.assertIn(
+                shape["id"],
+                briefing,
+                f"shape id {shape['id']!r} missing from briefing",
+            )
+
+    def test_briefing_contains_the_guarded_twin_text(self):
+        briefing = self.mod.build_briefing()
+        shapes = self._shapes()
+        # The literal guarded-twin string of every shape must appear.
+        for shape in shapes:
+            self.assertIn(shape["guarded_twin"], briefing)
+        # And the "guarded twin (the fix)" label frames it.
+        self.assertIn("guarded twin (the fix)", briefing)
+
+    def test_briefing_contains_the_three_agent_rules(self):
+        briefing = self.mod.build_briefing()
+        self.assertIn("Confirm, don't re-litigate", briefing)
+        self.assertIn("Skip the known false-positive classes", briefing)
+        self.assertIn("Hunt siblings via the guarded twin", briefing)
+
+    def test_briefing_includes_triage_rules_and_fp_taxonomy(self):
+        briefing = self.mod.build_briefing()
+        # A distinctive phrase from triage_rules.
+        self.assertIn("guarded twin is the strongest static-review signal", briefing)
+        # A distinctive heading from the FP taxonomy markdown.
+        self.assertIn("CPython false-positive taxonomy", briefing)
+        self.assertIn("false-positive", briefing.lower())
+
+    def test_briefing_lists_the_scanner_per_shape(self):
+        briefing = self.mod.build_briefing()
+        # Each shape names the scanner that surfaces it.
+        self.assertIn("scan_recursion_guards.py", briefing)
+        self.assertIn("surfaced by", briefing)
+
+    # --- catalog-dir behavior ----------------------------------------------
+
+    def test_catalog_dir_adds_findings_section(self):
+        with tempfile.TemporaryDirectory(prefix="cpyrt_catalog_") as tmp:
+            report = Path(tmp) / "reports" / "CRF-0001-tuple-hash-overflow"
+            report.mkdir(parents=True)
+            (report / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "id": "CRF-0001",
+                        "title": "tuple_hash native-stack overflow on deep nesting",
+                        "status": "reported",
+                        "sites": ["Objects/tupleobject.c tuple_hash:412"],
+                        "category": "unguarded-recursion-in-slot",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            briefing = self.mod.build_briefing(catalog_dir=tmp)
+
+        self.assertIn("Previously-recorded findings", briefing)
+        self.assertIn("confirm, don't re-litigate", briefing.lower())
+        self.assertIn("CRF-0001", briefing)
+        self.assertIn("tuple_hash native-stack overflow on deep nesting", briefing)
+        self.assertIn("Objects/tupleobject.c tuple_hash:412", briefing)
+        self.assertIn("reported", briefing)
+
+    def test_catalog_dir_tolerates_signature_dict_layout(self):
+        # meta.json using the dict-shaped `signature` (OOM-findings layout).
+        with tempfile.TemporaryDirectory(prefix="cpyrt_catalog_") as tmp:
+            report = Path(tmp) / "reports" / "CRF-0002-double-free"
+            report.mkdir(parents=True)
+            (report / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "id": "CRF-0002",
+                        "title": "double-free on error path",
+                        "signature": {"site_frame": "foo@Parser/pegen_errors.c:363"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            briefing = self.mod.build_briefing(catalog_dir=tmp)
+
+        self.assertIn("CRF-0002", briefing)
+        self.assertIn("foo@Parser/pegen_errors.c:363", briefing)
+        # Missing status defaults to "confirmed".
+        self.assertIn("confirmed", briefing)
+
+    def test_missing_catalog_dir_omits_section_gracefully(self):
+        briefing = self.mod.build_briefing(catalog_dir="/nonexistent/path/xyz")
+        self.assertNotIn("Previously-recorded findings", briefing)
+        # The rest of the briefing is still well-formed.
+        self.assertIn("Bug-shape catalog", briefing)
+
+    def test_empty_catalog_dir_omits_section(self):
+        with tempfile.TemporaryDirectory(prefix="cpyrt_catalog_") as tmp:
+            briefing = self.mod.build_briefing(catalog_dir=tmp)
+        self.assertNotIn("Previously-recorded findings", briefing)
+
+    def test_no_catalog_dir_omits_section(self):
+        briefing = self.mod.build_briefing()
+        self.assertNotIn("Previously-recorded findings", briefing)
+
+    # --- overrides / degradation -------------------------------------------
+
+    def test_custom_shapes_path_is_used(self):
+        with tempfile.TemporaryDirectory(prefix="cpyrt_shapes_") as tmp:
+            shapes_file = Path(tmp) / "shapes.json"
+            shapes_file.write_text(
+                json.dumps(
+                    {
+                        "shapes": [
+                            {
+                                "id": "planted-shape-xyz",
+                                "title": "a planted shape",
+                                "pattern": "some pattern",
+                                "guarded_twin": "the planted guarded twin",
+                                "hunt": "hunt directive",
+                                "severity": "FIX",
+                                "scanner": "planted_scanner.py",
+                            }
+                        ],
+                        "triage_rules": ["a planted triage rule"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            briefing = self.mod.build_briefing(shapes_path=str(shapes_file))
+
+        self.assertIn("planted-shape-xyz", briefing)
+        self.assertIn("the planted guarded twin", briefing)
+        self.assertIn("a planted triage rule", briefing)
+
+    def test_missing_shapes_file_degrades_gracefully(self):
+        briefing = self.mod.build_briefing(
+            shapes_path="/nonexistent/shapes.json",
+            non_bugs_path="/nonexistent/nonbugs.md",
+        )
+        # No crash; the three rules and headings still render.
+        self.assertIn("Your three informed-mode rules", briefing)
+        self.assertIn("no shapes loaded", briefing)
+        self.assertIn("taxonomy file missing", briefing)
+
+    def test_output_is_markdown_not_json(self):
+        briefing = self.mod.build_briefing()
+        self.assertTrue(briefing.lstrip().startswith("#"))
+        self.assertTrue(briefing.endswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_known_issues.py
+++ b/tests/test_check_known_issues.py
@@ -1,0 +1,242 @@
+"""Tests for check_known_issues.py — the known-issues regression command."""
+
+import unittest
+from pathlib import Path
+
+from helpers import TempProject, import_script
+
+# A tp_dealloc with an unguarded PyErr_Clear() — the pyerr-clear scanner flags
+# this (exception-clobbering in the destructor family).
+_PRESENT_DEALLOC = (
+    '#include "Python.h"\n'
+    "static void\n"
+    "present_dealloc(PyObject *self)\n"
+    "{\n"
+    '    if (PyObject_CallMethod(self, "close", NULL) == NULL) {\n'
+    "        PyErr_Clear();\n"
+    "    }\n"
+    "    Py_TYPE(self)->tp_free(self);\n"
+    "}\n"
+)
+
+# A clean dealloc — no PyErr_Clear, so the scanner finds nothing here.
+_CLEAN_DEALLOC = (
+    '#include "Python.h"\n'
+    "static void\n"
+    "clean_dealloc(PyObject *self)\n"
+    "{\n"
+    "    Py_XDECREF(((FooObject *)self)->attr);\n"
+    "    Py_TYPE(self)->tp_free(self);\n"
+    "}\n"
+)
+
+
+def _tsv(rows: list[tuple]) -> str:
+    """Build a TAB-separated catalog body from (bug_id, path, line, cat, fn, note)."""
+    header = "# bug_id\tpath\tline\tcategory\tfunction\tnote\n"
+    return header + "".join("\t".join(str(c) for c in row) + "\n" for row in rows)
+
+
+class TestCheckKnownIssues(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("check_known_issues")
+
+    def _run(self, files: dict, rows: list[tuple]) -> dict:
+        files = dict(files)
+        files["known.tsv"] = _tsv(rows)
+        with TempProject(files) as root:
+            catalog = str(Path(root) / "known.tsv")
+            return self.mod.analyze(str(root), catalog_path=catalog)
+
+    def _result_for(self, report: dict, bug_id: str) -> dict:
+        return next(r for r in report["catalog_results"] if r["bug_id"] == bug_id)
+
+    # --- present -----------------------------------------------------------
+
+    def test_present_matches_by_function_when_line_unknown(self):
+        report = self._run(
+            {"Objects/present.c": _PRESENT_DEALLOC},
+            [
+                (
+                    "PRESENT-1",
+                    "Objects/present.c",
+                    0,
+                    "pyerr-clear",
+                    "present_dealloc",
+                    "planted",
+                )
+            ],
+        )
+        entry = self._result_for(report, "PRESENT-1")
+        self.assertEqual(entry["status"], "present")
+        self.assertEqual(report["bug_rollup"]["PRESENT-1"], "present")
+        # And it surfaces as an actionable finding.
+        f = next(f for f in report["findings"] if f["bug_id"] == "PRESENT-1")
+        self.assertEqual(f["type"], "known_bug_present")
+        self.assertEqual(f["confidence"], "high")
+        self.assertEqual(f["file"], "Objects/present.c")
+
+    def test_present_matches_within_drift_window(self):
+        # The PyErr_Clear sits on line 6; a catalog line a couple lines off
+        # still counts as present (within the ±drift window).
+        report = self._run(
+            {"Objects/present.c": _PRESENT_DEALLOC},
+            [
+                (
+                    "PRESENT-2",
+                    "Objects/present.c",
+                    7,
+                    "pyerr-clear",
+                    "present_dealloc",
+                    "near",
+                )
+            ],
+        )
+        self.assertEqual(self._result_for(report, "PRESENT-2")["status"], "present")
+
+    # --- absent ------------------------------------------------------------
+
+    def test_absent_when_file_scanned_but_clean(self):
+        report = self._run(
+            {"Objects/clean.c": _CLEAN_DEALLOC},
+            [
+                (
+                    "ABSENT-1",
+                    "Objects/clean.c",
+                    0,
+                    "pyerr-clear",
+                    "clean_dealloc",
+                    "should be gone",
+                )
+            ],
+        )
+        entry = self._result_for(report, "ABSENT-1")
+        self.assertEqual(entry["status"], "absent")
+        self.assertEqual(report["bug_rollup"]["ABSENT-1"], "likely_fixed")
+        # Absent entries never become actionable findings.
+        self.assertFalse(any(f["bug_id"] == "ABSENT-1" for f in report["findings"]))
+
+    # --- line_drifted ------------------------------------------------------
+
+    def test_line_drifted_when_findings_exist_but_off_site(self):
+        # Known line far from the real finding, and an unknown function ("0"),
+        # so neither the line window nor the function name matches.
+        report = self._run(
+            {"Objects/present.c": _PRESENT_DEALLOC},
+            [("DRIFT-1", "Objects/present.c", 400, "pyerr-clear", "0", "moved")],
+        )
+        entry = self._result_for(report, "DRIFT-1")
+        self.assertEqual(entry["status"], "line_drifted")
+        self.assertIsNotNone(entry["nearest_line"])
+
+    # --- file_missing ------------------------------------------------------
+
+    def test_file_missing_when_path_absent(self):
+        report = self._run(
+            {"Objects/present.c": _PRESENT_DEALLOC},
+            [
+                (
+                    "MISSING-1",
+                    "Objects/ghost.c",
+                    0,
+                    "pyerr-clear",
+                    "ghost_dealloc",
+                    "gone",
+                )
+            ],
+        )
+        entry = self._result_for(report, "MISSING-1")
+        self.assertEqual(entry["status"], "file_missing")
+        self.assertEqual(report["bug_rollup"]["MISSING-1"], "likely_fixed")
+
+    # --- no_scanner passthrough --------------------------------------------
+
+    def test_no_scanner_categories_pass_through(self):
+        report = self._run(
+            {"Objects/present.c": _PRESENT_DEALLOC},
+            [
+                ("TSAN-1", "Objects/present.c", 10, "tsan", "some_race", "data race"),
+                (
+                    "INIT-1",
+                    "Objects/present.c",
+                    0,
+                    "init-bypass",
+                    "0",
+                    "__new__ bypass",
+                ),
+            ],
+        )
+        self.assertEqual(self._result_for(report, "TSAN-1")["status"], "no_scanner")
+        self.assertEqual(self._result_for(report, "INIT-1")["status"], "no_scanner")
+        self.assertEqual(report["bug_rollup"]["TSAN-1"], "no_scanner")
+        # no_scanner entries are never scanned and never actionable findings.
+        self.assertFalse(any(f["bug_id"] == "TSAN-1" for f in report["findings"]))
+
+    # --- bug_rollup collapsing multi-site bugs -----------------------------
+
+    def test_multi_site_rollup_present_wins(self):
+        report = self._run(
+            {
+                "Objects/present.c": _PRESENT_DEALLOC,
+                "Objects/clean.c": _CLEAN_DEALLOC,
+            },
+            [
+                (
+                    "MULTI-1",
+                    "Objects/clean.c",
+                    0,
+                    "pyerr-clear",
+                    "clean_dealloc",
+                    "site a",
+                ),
+                (
+                    "MULTI-1",
+                    "Objects/present.c",
+                    0,
+                    "pyerr-clear",
+                    "present_dealloc",
+                    "site b",
+                ),
+            ],
+        )
+        # One site absent, one present -> the bug rolls up to present.
+        self.assertEqual(report["bug_rollup"]["MULTI-1"], "present")
+
+    # --- envelope shape ----------------------------------------------------
+
+    def test_envelope_shape(self):
+        report = self._run(
+            {"Objects/present.c": _PRESENT_DEALLOC},
+            [
+                (
+                    "PRESENT-1",
+                    "Objects/present.c",
+                    0,
+                    "pyerr-clear",
+                    "present_dealloc",
+                    "x",
+                )
+            ],
+        )
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+            "catalog_summary",
+            "bug_rollup",
+            "catalog_results",
+            "notes",
+        ):
+            self.assertIn(key, report)
+        cs = report["catalog_summary"]
+        self.assertEqual(cs["catalog_entries"], 1)
+        self.assertIn("status_counts", cs)
+        # The absent-is-not-a-fix caveat must be baked into the JSON notes.
+        self.assertTrue(any("absent" in n.lower() for n in report["notes"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_pyerr_clear.py
+++ b/tests/test_scan_pyerr_clear.py
@@ -1,0 +1,222 @@
+"""Tests for scan_pyerr_clear.py — exception-clobbering in the destructor family."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanPyErrClear(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_pyerr_clear")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            result = self.mod.analyze(str(root))
+        return result
+
+    # --- true positives ----------------------------------------------------
+
+    def test_unguarded_clear_in_dealloc_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "foo_dealloc(PyObject *self)\n"
+                    "{\n"
+                    '    if (PyObject_CallMethod(self, "close", NULL) == NULL) {\n'
+                    "        PyErr_Clear();\n"
+                    "    }\n"
+                    "    Py_TYPE(self)->tp_free(self);\n"
+                    "}\n"
+                )
+            }
+        )
+        types = [f["type"] for f in result["findings"]]
+        self.assertIn("pyerr_clear_in_dealloc", types)
+        f = next(f for f in result["findings"] if f["type"] == "pyerr_clear_in_dealloc")
+        self.assertEqual(f["function"], "foo_dealloc")
+        self.assertEqual(f["slot"], "tp_dealloc")
+        self.assertEqual(f["confidence"], "high")
+
+    def test_clear_in_finalize_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/bar.c": (
+                    "static void\n"
+                    "bar_finalize(PyObject *self)\n"
+                    "{\n"
+                    "    PyErr_Clear();\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertTrue(any(f["slot"] == "tp_finalize" for f in result["findings"]))
+
+    def test_slot_designated_function_without_suffix_is_flagged(self):
+        # A teardown function whose name does NOT end in _dealloc, but which is
+        # wired to tp_dealloc via a static PyTypeObject initializer.
+        result = self._findings(
+            {
+                "Objects/baz.c": (
+                    "static void\n"
+                    "baz_teardown(PyObject *self)\n"
+                    "{\n"
+                    "    PyErr_Clear();\n"
+                    "    Py_TYPE(self)->tp_free(self);\n"
+                    "}\n"
+                    "static PyTypeObject Baz_Type = {\n"
+                    "    PyVarObject_HEAD_INIT(NULL, 0)\n"
+                    '    .tp_name = "baz",\n'
+                    "    .tp_dealloc = baz_teardown,\n"
+                    "};\n"
+                )
+            }
+        )
+        funcs = [f["function"] for f in result["findings"]]
+        self.assertIn("baz_teardown", funcs)
+
+    def test_slot_spec_designated_function_is_flagged(self):
+        result = self._findings(
+            {
+                "Modules/qux.c": (
+                    "static void\n"
+                    "qux_free(PyObject *self)\n"
+                    "{\n"
+                    "    PyErr_Clear();\n"
+                    "}\n"
+                    "static PyType_Slot qux_slots[] = {\n"
+                    "    {Py_tp_dealloc, qux_free},\n"
+                    "    {0, NULL},\n"
+                    "};\n"
+                )
+            }
+        )
+        self.assertIn("qux_free", [f["function"] for f in result["findings"]])
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_clear_outside_destructor_is_not_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_getattr(PyObject *self, PyObject *name)\n"
+                    "{\n"
+                    "    PyObject *r = PyObject_GenericGetAttr(self, name);\n"
+                    "    if (r == NULL) {\n"
+                    "        PyErr_Clear();\n"
+                    "    }\n"
+                    "    return r;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_dealloc_with_save_restore_is_suppressed(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(PyObject *self)\n"
+                    "{\n"
+                    "    PyObject *exc = PyErr_GetRaisedException();\n"
+                    '    if (PyObject_CallMethod(self, "close", NULL) == NULL) {\n'
+                    "        PyErr_Clear();\n"
+                    "    }\n"
+                    "    PyErr_SetRaisedException(exc);\n"
+                    "    Py_TYPE(self)->tp_free(self);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_dealloc_with_writeunraisable_is_suppressed(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(PyObject *self)\n"
+                    "{\n"
+                    "    if (something_failed()) {\n"
+                    "        PyErr_WriteUnraisable(self);\n"
+                    "        PyErr_Clear();\n"
+                    "    }\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_dealloc_without_clear_is_not_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(PyObject *self)\n"
+                    "{\n"
+                    "    Py_XDECREF(((FooObject *)self)->attr);\n"
+                    "    Py_TYPE(self)->tp_free(self);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(PyObject *self)\n"
+                    "{\n"
+                    "    /* intentional: no exception can be live here */\n"
+                    "    PyErr_Clear();\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    # --- CPython-specific edge ---------------------------------------------
+
+    def test_traverse_clear_is_medium_confidence(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static int\n"
+                    "foo_traverse(PyObject *self, visitproc visit, void *arg)\n"
+                    "{\n"
+                    "    PyErr_Clear();\n"
+                    "    return 0;\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["function"] == "foo_traverse"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["slot"], "tp_traverse")
+        self.assertEqual(f["confidence"], "medium")
+
+    def test_envelope_shape(self):
+        result = self._findings(
+            {"Objects/foo.c": "static void foo_dealloc(PyObject *self) { }\n"}
+        )
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_recursion_guards.py
+++ b/tests/test_scan_recursion_guards.py
@@ -1,0 +1,188 @@
+"""Tests for scan_recursion_guards.py — recursion-prone slots lacking a guard."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanRecursionGuards(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_recursion_guards")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    # --- true positives ----------------------------------------------------
+
+    def test_container_hash_without_guard_is_flagged(self):
+        # The tuple_hash / frozendict_hash class (gh-154318): loop over items
+        # calling PyObject_Hash with no Py_EnterRecursiveCall.
+        result = self._findings(
+            {
+                "Objects/mytuple.c": (
+                    "static Py_hash_t\n"
+                    "mytuple_hash(PyObject *self)\n"
+                    "{\n"
+                    "    Py_ssize_t len = Py_SIZE(self);\n"
+                    "    Py_uhash_t acc = 0;\n"
+                    "    for (Py_ssize_t i = 0; i < len; i++) {\n"
+                    "        Py_hash_t y = PyObject_Hash(GET_ITEM(self, i));\n"
+                    "        acc = (acc * 1000003) ^ (Py_uhash_t)y;\n"
+                    "    }\n"
+                    "    return (Py_hash_t)acc;\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["function"] == "mytuple_hash"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["type"], "missing_recursion_guard")
+        self.assertEqual(f["slot"], "tp_hash")
+        self.assertEqual(f["shape"], "container_element_descent")
+        self.assertEqual(f["confidence"], "high")
+
+    def test_self_recursive_parameter_walk_is_flagged(self):
+        # The _Py_make_parameters class (gh-154275): self-recursion, no guard.
+        result = self._findings(
+            {
+                "Objects/genericaliasobject.c": (
+                    "static PyObject *\n"
+                    "make_parameters(PyObject *args)\n"
+                    "{\n"
+                    "    PyObject *sub = make_parameters(inner(args));\n"
+                    "    return sub;\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["function"] == "make_parameters"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["slot"], "parameter_walk")
+        self.assertEqual(f["shape"], "self_recursion")
+        self.assertEqual(f["confidence"], "high")
+
+    def test_slot_designated_richcompare_descent_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/myseq.c": (
+                    "static PyObject *\n"
+                    "myseq_cmp(PyObject *a, PyObject *b, int op)\n"
+                    "{\n"
+                    "    for (Py_ssize_t i = 0; i < n; i++) {\n"
+                    "        int r = PyObject_RichCompareBool("
+                    "GET_ITEM(a, i), GET_ITEM(b, i), Py_EQ);\n"
+                    "        if (r < 0) return NULL;\n"
+                    "    }\n"
+                    "    Py_RETURN_TRUE;\n"
+                    "}\n"
+                    "static PyTypeObject Seq_Type = {\n"
+                    "    .tp_richcompare = myseq_cmp,\n"
+                    "};\n"
+                )
+            }
+        )
+        f = next((f for f in result["findings"] if f["function"] == "myseq_cmp"), None)
+        self.assertIsNotNone(f)
+        self.assertEqual(f["slot"], "tp_richcompare")
+        self.assertEqual(f["confidence"], "high")
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_guarded_recursion_is_suppressed(self):
+        result = self._findings(
+            {
+                "Objects/mytuple.c": (
+                    "static Py_hash_t\n"
+                    "mytuple_hash(PyObject *self)\n"
+                    "{\n"
+                    '    if (Py_EnterRecursiveCall(" while hashing")) return -1;\n'
+                    "    for (Py_ssize_t i = 0; i < n; i++) {\n"
+                    "        PyObject_Hash(GET_ITEM(self, i));\n"
+                    "    }\n"
+                    "    Py_LeaveRecursiveCall();\n"
+                    "    return 0;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_repr_with_reprenter_is_suppressed(self):
+        result = self._findings(
+            {
+                "Objects/mylist.c": (
+                    "static PyObject *\n"
+                    "mylist_repr(PyObject *self)\n"
+                    "{\n"
+                    "    if (Py_ReprEnter(self) != 0) return NULL;\n"
+                    "    for (Py_ssize_t i = 0; i < n; i++) {\n"
+                    "        PyObject_Repr(GET_ITEM(self, i));\n"
+                    "    }\n"
+                    "    Py_ReprLeave(self);\n"
+                    "    return NULL;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_scalar_hash_without_descent_is_not_flagged(self):
+        # Hashes a single field, no loop, no self-call -> bounded, not flagged.
+        result = self._findings(
+            {
+                "Objects/point.c": (
+                    "static Py_hash_t\n"
+                    "point_hash(PyObject *self)\n"
+                    "{\n"
+                    "    return PyObject_Hash(((PointObject *)self)->x);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_non_slot_self_recursion_is_not_flagged(self):
+        # A plain helper that self-recurses but is not a recursion-prone slot
+        # is out of scope (keeps false positives down).
+        result = self._findings(
+            {
+                "Objects/util.c": (
+                    "static int\n"
+                    "count_down(int n)\n"
+                    "{\n"
+                    "    if (n <= 0) return 0;\n"
+                    "    return count_down(n - 1);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/mytuple.c": (
+                    "static Py_hash_t\n"
+                    "mytuple_hash(PyObject *self)\n"
+                    "{\n"
+                    "    /* safe because elements are guaranteed non-container scalars */\n"
+                    "    for (Py_ssize_t i = 0; i < n; i++) {\n"
+                    "        PyObject_Hash(GET_ITEM(self, i));\n"
+                    "    }\n"
+                    "    return 0;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_uninit_dealloc.py
+++ b/tests/test_scan_uninit_dealloc.py
@@ -1,0 +1,163 @@
+"""Tests for scan_uninit_dealloc.py — freeing a half-constructed object."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanUninitDealloc(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_uninit_dealloc")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    # --- true positives ----------------------------------------------------
+
+    def test_free_before_member_init_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/templateobject.c": (
+                    "static PyObject *\n"
+                    "template_iter_new(PyTypeObject *type, PyObject *tmpl)\n"
+                    "{\n"
+                    "    TemplateIter *it = PyObject_GC_New(TemplateIter, type);\n"
+                    "    if (it == NULL) {\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    it->stringsiter = PyObject_GetIter(tmpl);\n"
+                    "    if (it->stringsiter == NULL) {\n"
+                    "        Py_DECREF(it);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    it->index = 0;\n"
+                    "    return (PyObject *)it;\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (
+                f
+                for f in result["findings"]
+                if f["type"] == "dealloc_of_uninitialized_object"
+            ),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["variable"], "it")
+        self.assertEqual(f["allocator"], "PyObject_GC_New")
+        self.assertEqual(f["confidence"], "medium")
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_memset_zeroed_is_safe(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    memset(op->fields, 0, sizeof(op->fields));\n"
+                    "    op->attr = PyList_New(0);\n"
+                    "    if (op->attr == NULL) { Py_DECREF(op); return NULL; }\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_members_nulled_before_error_is_safe(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = NULL;\n"
+                    "    op->other = NULL;\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) { Py_DECREF(op); return NULL; }\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_zeroing_allocator_is_safe(self):
+        # tp_alloc / PyType_GenericAlloc zero the object; not flagged.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = (FooObject *)type->tp_alloc(type, 0);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) { Py_DECREF(op); return NULL; }\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_no_early_free_is_safe(self):
+        # Object never freed inside the constructor -> nothing to flag.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = NULL;\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    /* intentional: dealloc handles the uninitialized case */\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) { Py_DECREF(op); return NULL; }\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_envelope_shape(self):
+        result = self._findings({"Objects/foo.c": "static void foo(void) { }\n"})
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **Tree-sitter-C chassis** (`tree_sitter_utils.py` vendored verbatim from the cext sibling + a CPython-adapted `scan_common.py`) — new scanners parse real function boundaries instead of regex.
- **Three crash-class detectors**, each scanner + agent + tests, validated against confirmed CPython crashes on the live tree: `recursion-guard-auditor` (gh-154318 `tuple_hash`, gh-154275 `_Py_make_parameters`, + novel `union_hash`), `pyerr-clear-auditor` (destructor-scoped; `deque_clear`, gh-152083), `uninitialized-dealloc-auditor` (gh-151815 `template_iter`).
- **Workflow machinery**: `known-issues` (regression baseline vs `data/cpython_known_bugs.tsv`) and `informed-explore` (catalog-seeded briefing from `data/cpython_bug_shapes.json` + FP taxonomy, with a `--catalog-dir` findings-repo hook).
- **Infra**: a `data/` layer (known bugs, bug shapes, reachability tiers, FP taxonomy), a `git-history-context` preflight agent with a shallow-clone guard, and wiring into `explore`/`hotspots`/`health`.
- **Release**: version → 0.5.0 (both manifests); `CHANGELOG.md` gets a `[0.5.0]` section (replacing the drifted `[Unreleased]`); both READMEs updated (counts, tree-sitter prerequisite, hybrid parsing).

Whole-tree yield across 752 C files is tight: recursion 12 (9 high), pyerr-clear 2 (both high), uninit-dealloc 16. Findings are static-confirmed; dynamic reproduction (a `set_nomemory` harness) and FT/TSan detectors are deferred to v0.6 (see `docs/improvement-plan.md`).

## Test plan
- [x] `python -m unittest discover tests` — **157 tests green** (was 110)
- [x] `mypy` clean on all authored scripts (the lone error is in the vendored chassis = upstream)
- [x] `ruff check` / `ruff format --check` clean on authored files
- [x] Smoke-run each detector + `known-issues` against a live CPython checkout; confirmed catches for gh-154318 / gh-154275 / gh-151815 and `deque_clear`
- [x] `tree_sitter_utils.py` byte-identical to the cext source (vendoring intact)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Ko7pYv9LY8wCj87eMH93oD