### PR TITLE
v0.6: free-threading / TSan detectors for CPython's own code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "cpython-review-toolkit",
-  "version": "0.5.0",
-  "description": "CPython C code exploration and analysis toolkit: specialized agents for refcount auditing, error path analysis, GIL discipline, NULL safety, complexity, include-graph mapping, PEP 7 style, deprecation, macros, and memory patterns — plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
+  "version": "0.6.0",
+  "description": "CPython C code exploration and analysis toolkit: specialized agents for refcount auditing, error path analysis, GIL discipline, NULL safety, complexity, include-graph mapping, PEP 7 style, deprecation, macros, and memory patterns \u2014 plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
   "owner": {
     "name": "Danzin",
     "email": "lafleurfuzzer@gmail.com"
@@ -12,7 +12,7 @@
       "name": "cpython-review-toolkit",
       "description": "Specialized agents and commands for exploring, analyzing, and reviewing CPython's C source code. Regex scanners for include-graph mapping, complexity, refcounts, error paths, GIL, and NULL safety, plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
       "source": "./plugins/cpython-review-toolkit",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "category": "code-quality",
       "keywords": [
         "cpython",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.0] - 2026-07-24
+
+The free-threading release. Uses the v0.5 tree-sitter chassis to add data-race
+detectors for CPython's own free-threaded (`Py_GIL_DISABLED`, PEP 703) code,
+grounded in the fusil `cpython-tsan-findings` catalog.
+
+### Added
+- **ft-race-scanner** + `scan_ft_races.py`: three TSan-grounded race classes —
+  T3 iterator-exhaustion double-DECREF (gh-154130 / gh-144357 / gh-153296), T2
+  lazy-init cache without a critical section (TSAN-0043 `descr_get_qualname`),
+  T1 atomic/plain access asymmetry (TSAN-0006 `count_repr`). Suppresses the
+  `*_lock_held` / `*_locked` caller-holds-the-lock convention.
+- **stw-safety-checker** + `scan_stw_safety.py` (ported from ft-review-toolkit):
+  flags calls inside a `_PyEval_StopTheWorld` region that can invoke Python / GC
+  / set an exception, via an intra-file call graph (now possible on the chassis).
+- **lock-discipline-checker** + `scan_lock_discipline.py` (ported): critical-
+  section acquire/release pairing, including the `Py_BEGIN_CRITICAL_SECTION_MUTEX`
+  spelling.
+- **tsan-report-analyzer** + `parse_tsan_report.py` and **tsan-stress-generator**
+  (ported, inverted for CPython: races in CPython's own frames ARE the target,
+  not noise to filter).
+- FT data files: `stw_safe_apis.json`, `lock_macros.json`,
+  `critical_section_apis.json`, `atomic_patterns.json`.
+
+### Changed
+- `known-issues`: the `tsan` catalog category is now scanned by `scan_ft_races`
+  (was `no_scanner` in v0.5). Only `init-bypass` remains scanner-less.
+- `explore` / `hotspots` / `health` wire the free-threading agents.
+- Version → 0.6.0 (both manifests).
+
 ## [0.5.0] - 2026-07-24
 
 The chassis-and-crash-classes release. Adopts a tree-sitter-C parsing chassis

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Start with `map` to understand the include graph, then `hotspots` to find the hi
 
 ## What's Included
 
-- **15 analysis agents** covering reference counting, error handling, GIL discipline, complexity, NULL safety, PEP 7 style, include dependencies, API deprecation, macro hygiene, memory patterns, and temporal history — plus tree-sitter-based **crash-class detectors** for recursion-guard gaps, destructor exception-clobber, and uninitialized-dealloc.
+- **20 analysis agents** covering reference counting, error handling, GIL discipline, complexity, NULL safety, PEP 7 style, include dependencies, API deprecation, macro hygiene, memory patterns, and temporal history — plus tree-sitter-based **crash-class detectors** (recursion-guard gaps, destructor exception-clobber, uninitialized-dealloc) and **free-threading / data-race detectors** (iterator double-DECREF, stop-the-world safety, lock discipline, TSan triage).
 - **6 commands** (`explore`, `informed-explore`, `known-issues`, `map`, `hotspots`, `health`) for different analysis workflows.
 - **Analysis scripts** — stdlib-only regex scanners for the legacy dimensions, plus tree-sitter crash-class detectors, a `known-issues` regression checker, and an `informed-explore` briefing generator.
 

--- a/plugins/cpython-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cpython-review-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cpython-review-toolkit",
-  "version": "0.5.0",
-  "description": "CPython C code exploration and analysis agents: refcount auditing, error path analysis, GIL discipline, C complexity, include-graph mapping, PEP 7 style, NULL safety, deprecation, macros, and memory patterns — plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command",
+  "version": "0.6.0",
+  "description": "CPython C code exploration and analysis agents: refcount auditing, error path analysis, GIL discipline, C complexity, include-graph mapping, PEP 7 style, NULL safety, deprecation, macros, and memory patterns \u2014 plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command",
   "author": {
     "name": "Danzin"
   }

--- a/plugins/cpython-review-toolkit/README.md
+++ b/plugins/cpython-review-toolkit/README.md
@@ -141,6 +141,25 @@ These target specific reachable-from-Python crash classes grounded in the fusil 
 | **pyerr-clear-auditor** | `PyErr_Clear()` in the destructor family (`tp_dealloc`/`tp_clear`/`tp_finalize`/`tp_traverse`) with no save/restore, swallowing an in-flight `MemoryError`/`KeyboardInterrupt` (gh-152083) | `scan_pyerr_clear.py` |
 | **uninitialized-dealloc-auditor** | Non-zeroing allocation freed on an error path before members are NULL-initialized → `tp_dealloc` reads garbage (gh-151815, gh-152851) | `scan_uninit_dealloc.py` |
 
+### Free-Threading / Data Races (tree-sitter based)
+
+These target CPython's own free-threaded (`Py_GIL_DISABLED`, PEP 703) code, grounded in the fusil `cpython-tsan-findings` catalog. The ft-review-toolkit that seeded them was calibrated against CPython's own runtime, so they are at home here.
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **ft-race-scanner** | T3 iterator-exhaustion double-DECREF (gh-154130/gh-144357/gh-153296), T2 lazy-init cache without a critical section (TSAN-0043), T1 atomic/plain access asymmetry (TSAN-0006). Suppresses the `*_lock_held` convention | `scan_ft_races.py` |
+| **stw-safety-checker** | Calls inside a `_PyEval_StopTheWorld` region that can invoke Python / GC / set an exception (intra-file call graph) | `scan_stw_safety.py` |
+| **lock-discipline-checker** | Critical-section acquire/release pairing — missing `Py_END_CRITICAL_SECTION`, early return/goto out of a section, nested different-object locks | `scan_lock_discipline.py` |
+
+### Dynamic (TSan) — on-demand
+
+Not part of the static explore pipeline; these consume/produce a ThreadSanitizer run on a `--disable-gil` build.
+
+| Agent | What It Does | Script |
+|-------|--------------|--------|
+| **tsan-report-analyzer** | Parses/dedups a TSan report; for CPython, races in CPython's own frames ARE the target (the extension-oriented filter is inverted) | `parse_tsan_report.py` |
+| **tsan-stress-generator** | Emits a concurrent stress script that hammers a shared stdlib object under `PYTHON_GIL=0` to trigger races | — (prompt) |
+
 ### Code Quality (script-backed)
 
 | Agent | What It Finds | Script |
@@ -248,6 +267,7 @@ The `explore` command runs agents in a structured pipeline:
 | **2A** | refcount-auditor, error-path-analyzer | Safety-critical (highest value) |
 | **2A2** | recursion-guard-auditor, pyerr-clear-auditor, uninitialized-dealloc-auditor | Crash-class detectors (tree-sitter) |
 | **2B** | null-safety-scanner, gil-discipline-checker | Memory safety |
+| **2B2** | ft-race-scanner, stw-safety-checker, lock-discipline-checker | Free-threading / data races (PEP 703) |
 | **2C** | c-complexity-analyzer, pep7-style-checker | Code quality |
 | **2D** | api-deprecation-tracker, macro-hygiene-reviewer, memory-pattern-analyzer | Maintenance |
 | **2E** | git-history-analyzer | Temporal fix-completeness (runs last) |
@@ -276,6 +296,11 @@ cpython-review-toolkit/
 │   ├── recursion-guard-auditor.md          # crash-class (tree-sitter)
 │   ├── pyerr-clear-auditor.md              # crash-class (tree-sitter)
 │   ├── uninitialized-dealloc-auditor.md    # crash-class (tree-sitter)
+│   ├── ft-race-scanner.md                  # free-threading (tree-sitter)
+│   ├── stw-safety-checker.md               # free-threading (tree-sitter)
+│   ├── lock-discipline-checker.md          # free-threading (tree-sitter)
+│   ├── tsan-report-analyzer.md             # dynamic TSan (on-demand)
+│   ├── tsan-stress-generator.md            # dynamic TSan (on-demand)
 │   ├── c-complexity-analyzer.md
 │   ├── pep7-style-checker.md
 │   ├── include-graph-mapper.md
@@ -295,7 +320,11 @@ cpython-review-toolkit/
 │   ├── cpython_known_bugs.tsv              # known-issues regression catalog
 │   ├── cpython_bug_shapes.json             # informed-explore bug shapes
 │   ├── cpython_reachability_sources.json   # T1/T2/T3 reachability tiers
-│   └── cpython_non_bugs.md                 # false-positive taxonomy
+│   ├── cpython_non_bugs.md                 # false-positive taxonomy
+│   ├── atomic_patterns.json                # free-threading (atomics)
+│   ├── stw_safe_apis.json                  # free-threading (STW safety)
+│   ├── lock_macros.json                    # free-threading (locks)
+│   └── critical_section_apis.json          # free-threading (critical sections)
 └── scripts/
     ├── tree_sitter_utils.py                # vendored C parsing chassis
     ├── scan_common.py                      # shared helpers
@@ -310,6 +339,10 @@ cpython-review-toolkit/
     ├── scan_recursion_guards.py            # tree-sitter detector
     ├── scan_pyerr_clear.py                 # tree-sitter detector
     ├── scan_uninit_dealloc.py              # tree-sitter detector
+    ├── scan_ft_races.py                    # free-threading detector
+    ├── scan_stw_safety.py                  # free-threading detector
+    ├── scan_lock_discipline.py             # free-threading detector
+    ├── parse_tsan_report.py                # dynamic TSan analyzer
     ├── check_known_issues.py               # known-issues command
     └── build_informed_briefing.py          # informed-explore briefing
 ```
@@ -323,8 +356,8 @@ cpython-review-toolkit/
 | **Root detection** | `pyproject.toml`, `.git` | `Include/Python.h`, `Objects/object.c` |
 | **Top bug class** | Logic errors, dead code | Refcount leaks, NULL deref, native-stack-overflow SIGSEGV, GIL violations |
 | **Style guide** | PEP 8 | PEP 7 |
-| **Agents** | 14 | 15 |
-| **Scripts** | 8 | 15 |
+| **Agents** | 14 | 20 |
+| **Scripts** | 8 | 19 |
 
 ## Author
 

--- a/plugins/cpython-review-toolkit/agents/ft-race-scanner.md
+++ b/plugins/cpython-review-toolkit/agents/ft-race-scanner.md
@@ -1,0 +1,67 @@
+---
+name: ft-race-scanner
+description: Use this agent to find free-threading data races in CPython's own C code — iterator-exhaustion double-DECREF, lazy-init caches without a critical section, and atomic/plain access asymmetry. Grounded in the fusil cpython-tsan-findings catalog. Uses scan_ft_races.py.\n\n<example>\nContext: The user wants to find data races in CPython's free-threaded build.\nuser: "Are there shared-iterator races in CPython's own objects?"\nassistant: "I'll use the ft-race-scanner to find tp_iternext functions that drop an owning reference without a critical section."\n<commentary>\ndict/set/StringIO iterator double-DECREFs (gh-154130 / gh-144357 / gh-153296) are confirmed instances of this class.\n</commentary>\n</example>
+model: opus
+color: purple
+---
+
+You are an expert in CPython's free-threaded (`Py_GIL_DISABLED`, PEP 703) runtime. Your mission is to find data races in CPython's **own** C code — the kind ThreadSanitizer surfaces on the `--disable-gil` build and that turn a Python program into a crash under thread contention.
+
+## Why this matters
+
+On the free-threaded build there is no GIL serializing access to shared objects. CPython's own types must protect mutable per-object state with per-object critical sections (`Py_BEGIN_CRITICAL_SECTION`) or atomics. Where they don't, two threads racing the same object corrupt it. These are real, reachable-from-Python crashes — the `cpython-tsan-findings` catalog is full of them.
+
+## Scope
+
+Analyze the scope provided (default: whole project; `Objects/`, `Python/`, `Modules/` are where it matters). Requires tree-sitter (`pip install tree-sitter tree-sitter-c`).
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/scan_ft_races.py [scope]
+```
+
+Findings carry an `ft_class`:
+- **T3** `iternext_double_decref` (confidence high) — a `tp_iternext` drops an owning ref to a shared self-member (`Py_CLEAR(it->it_seq)` or `it->seq = NULL; Py_DECREF(seq)`) with no critical section. Two `next()` threads → double-free.
+- **T2** `lazy_init_no_critical_section` (medium) — `if (!self->f) self->f = compute();` with no critical section. Two threads both compute/store.
+- **T1** `atomic_plain_asymmetry` (low) — a field accessed via `_Py_atomic_*`/`FT_ATOMIC_*` at one site and plainly at another in the same file.
+
+The scanner suppresses `*_lock_held` / `*_locked` functions (the caller holds the section) and any function that itself takes a critical section.
+
+## Analysis Strategy
+
+### Phase 1: Is the object actually shared and mutated concurrently?
+- **T3** is the highest-signal: a shared iterator (one iterator object advanced by two threads) hitting the exhaustion drop is the confirmed double-free (gh-154130 dict, gh-144357 set, gh-153296 StringIO). Confirm the member being dropped is the *owning* reference to the iterated container, and that the iterator can be shared (it can — nothing stops two threads calling `next()` on the same iterator). → **FIX**.
+- **T2**: confirm the field is genuinely lazy-init shared state (a cache computed once), not a single-threaded init path. A racing double-init that leaks or hands out a torn pointer is **FIX**; a provably single-threaded path is ACCEPTABLE.
+- **T1**: confirm the atomic and plain accesses touch the *same* field on a concurrently-shared object. Many are `#ifdef Py_GIL_DISABLED` split paths or init-time plain writes — those are ACCEPTABLE. A genuine plain read racing an atomic writer (e.g. `count_repr` vs the atomic counter, TSAN-0006) is **CONSIDER**.
+
+### Phase 2: TSan reproduction (high-value)
+Build CPython `--disable-gil` with ThreadSanitizer, then hammer the suspect object from multiple threads with `PYTHON_GIL=0` (the `tsan-stress-generator` agent writes the script; `tsan-report-analyzer` triages the output). A reported race at the flagged site confirms it — record it in `cpython-tsan-findings`.
+
+## Output Format
+
+```markdown
+## Free-Threading Race Analysis Results
+
+### Summary
+- T3 iterator double-DECREF: N (high)
+- T2 lazy-init w/o critical section: N (medium)
+- T1 atomic/plain asymmetry: N (low)
+
+### Findings
+
+#### [FIX] Shared dict iterator double-DECREF (Objects/dictobject.c:LINE)
+**What**: `dictiter_iternext*` drops `di->di_dict` on exhaustion with no Py_BEGIN_CRITICAL_SECTION.
+**Impact**: two concurrent next() calls double-free the dict (gh-154130).
+**Fix**: wrap the iternext body in `Py_BEGIN_CRITICAL_SECTION(self)`.
+```
+
+## Classification Guide
+- **FIX**: a confirmed-shape T3 on a shareable iterator, or a T2 lazy-init of genuinely shared cache state. Cross-reference the tsan catalog (TSAN-####) and the tracker.
+- **CONSIDER**: T1 asymmetry on a plausibly-shared field; T2 where sharing is likely but unproven.
+- **ACCEPTABLE**: single-threaded init paths, `#ifdef Py_GIL_DISABLED` split accesses, immutable-after-construction fields.
+
+## Important Guidelines
+- **This is syntactic and intra-function/intra-file.** It cannot prove two threads reach the site concurrently — Phase 1 triage + Phase 2 TSan reproduction is where FIX-confidence is earned.
+- **Free-threading is the calibration frame, not a discount.** CPython declares free-threaded support, so a real race here is a bug, not a future concern — but confirm the sharing before escalating a T1/T2 to FIX.
+- **The guarded twin is the fix.** A sibling method on the same type that *does* take `Py_BEGIN_CRITICAL_SECTION` is both the proof the field needs protection and the fix pattern.

--- a/plugins/cpython-review-toolkit/agents/lock-discipline-checker.md
+++ b/plugins/cpython-review-toolkit/agents/lock-discipline-checker.md
@@ -1,0 +1,85 @@
+---
+name: lock-discipline-checker
+description: Use this agent to audit critical-section discipline in CPython's own C source — Py_BEGIN_CRITICAL_SECTION / Py_END_CRITICAL_SECTION pairs that leak the per-object lock on an early return or goto, and two-object locking that should use the deadlock-safe Py_BEGIN_CRITICAL_SECTION2. Uses scan_lock_discipline.py.\n\n<example>\nContext: The user is reviewing free-threading changes in an object implementation.\nuser: "Do any of the critical sections in dictobject.c leak on an error path?"\nassistant: "I'll use the lock-discipline-checker to find Py_BEGIN_CRITICAL_SECTION without a matching END on some path (early return / out-of-section goto), and nested different-object locks."\n<commentary>\nThe critical-section macros are scoped: leaving without the END keeps the object locked. This agent finds those leaks intra-function.\n</commentary>\n</example>
+model: opus
+color: yellow
+---
+
+You are an expert in CPython's free-threading (PEP 703) critical-section discipline. Your mission is to verify that every `Py_BEGIN_CRITICAL_SECTION` is closed by its matching `Py_END_CRITICAL_SECTION` on **every** path, and to flag two-object locking that risks deadlock.
+
+## Why this matters
+
+The critical-section macros are **scoped**. In `Include/cpython/pycritical_section.h`, `Py_BEGIN_CRITICAL_SECTION(op)` opens a brace and declares a stack-local `PyCriticalSection` that `_PyCriticalSection_Begin` pushes; `Py_END_CRITICAL_SECTION()` pops it. Leave the section on any path without the matching END and:
+
+- The per-object lock is **never released** — the moment a second thread contends the object, both deadlock.
+- Because the local is scoped, you **cannot** `goto` out to an external cleanup label and call `Py_END` there (it would reference an out-of-scope local). The correct release-then-exit idiom is `Py_END_CRITICAL_SECTION(); return X;` or `Py_END_CRITICAL_SECTION(); goto error;` — the END comes **first**.
+
+CPython uses these pervasively (`Objects/dictobject.c` alone has dozens). The common correct idiom — begin, work, end on every path — is silent by design; only leaks and deadlock-risky nesting surface.
+
+## Scope
+
+Analyze the scope provided. Default: the entire checkout. Requires tree-sitter (`pip install tree-sitter tree-sitter-c`). **Intra-function only** — a section opened in one function and closed in another is out of scope and honestly not modelled; say so when a finding straddles a helper boundary.
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/scan_lock_discipline.py [scope] [--max-files N]
+```
+
+Run with a Bash timeout of **300000 ms** on a full checkout, and write JSON to a unique temp path (e.g. `/tmp/lock-discipline_<scope>_$$.json`). If the script times out or errors, do **not** retry — fall back to Grep/Read for the same question.
+
+| Finding type | Classification | Meaning |
+|---|---|---|
+| `critical_section_missing_end` | FIX | A begin with no matching END on any path — lock never released. |
+| `critical_section_end_on_error` | FIX | A `return` / out-of-section `goto` sits between a begin and its END without releasing first. |
+| `nested_critical_sections` | CONSIDER | Two different objects locked at once via two single-object begins (deadlock risk). |
+
+The scanner recognizes all three begin spellings: `Py_BEGIN_CRITICAL_SECTION`, `Py_BEGIN_CRITICAL_SECTION2`, and the mutex-backed `Py_BEGIN_CRITICAL_SECTION_MUTEX(&m)` (paired with the ordinary `Py_END_CRITICAL_SECTION()`). A `goto` whose target label is *inside* the section (a `retry:` loop) is treated as an internal jump, not an exit. Comment-suppressed sites (`/* intentional ... */`, `safety:` etc.) are dropped.
+
+## Analysis Strategy
+
+### Phase 1: Triage each leak (FIX candidates)
+For every `critical_section_missing_end` / `critical_section_end_on_error`:
+1. Read ~30 lines around the flagged line.
+2. Confirm the exit truly leaves the section open. Watch for a `Py_END_CRITICAL_SECTION()` on the *same line* or an intervening line the byte-ordering missed, or a helper macro that expands to the END.
+3. Confirm the begin/end are in the **same** function. If the END lives in a wrapper the caller invokes, downgrade to CONSIDER and note the intra-function limitation.
+4. The fix is almost always: insert `Py_END_CRITICAL_SECTION();` (or the `2` / matching variant) immediately before the `return` / `goto`.
+
+### Phase 2: Assess nested locking (CONSIDER)
+For each `nested_critical_sections`:
+1. Are the two objects genuinely distinct at runtime? (If `a` and `b` can alias, the ordering point is moot.)
+2. Does any *other* function lock the same two objects in the opposite order? If yes, that is a concrete lock-ordering cycle — escalate toward FIX.
+3. The idiomatic fix is `Py_BEGIN_CRITICAL_SECTION2(a, b)`, which acquires both in a canonical (address-ordered) order and closes with `Py_END_CRITICAL_SECTION2()`.
+
+### Phase 3: Widen manually
+The scanner is intra-function and pattern-based. Also grep for:
+- `Py_BEGIN_CRITICAL_SECTION` counts vs `Py_END_CRITICAL_SECTION` counts per file (gross imbalance hints at a cross-branch leak the LIFO pairing smoothed over).
+- Sections wrapping a call that can itself re-enter Python and drop the lock.
+
+## Output Format
+
+```markdown
+## Critical-Section Discipline Results
+
+### Summary
+- Functions with critical sections: N
+- FIX (leaked lock — missing/early-exit END): N
+- CONSIDER (nested two-object locking): N
+
+### Findings
+
+#### [FIX] foo_method leaks self's lock on the error path (Objects/foo.c:LINE)
+**What**: `return NULL` between `Py_BEGIN_CRITICAL_SECTION(self)` (line L1) and `Py_END_CRITICAL_SECTION()` (line L2).
+**Impact**: `self` stays locked; a second thread contending it deadlocks.
+**Fix**: `Py_END_CRITICAL_SECTION();` before the `return NULL;`.
+```
+
+## Classification Guide
+- **FIX**: a confirmed intra-function leak — a begin with no END, or an exit between begin and END that does not release first.
+- **CONSIDER**: two-object nesting (recommend `Py_BEGIN_CRITICAL_SECTION2`); or a leak you cannot confirm because the END is in another function.
+- **ACCEPTABLE**: the release is present on the path (scanner byte-ordering artifact), or the object is provably uncontended.
+
+## Important Guidelines
+- **The common correct idiom is not a finding.** Do not flag begin/work/end sections that release on every path.
+- **`Py_END` must come before the exit**, never after via a goto to an external label — that pattern does not even compile for scoped critical sections.
+- **Report at most 20 findings**, FIX before CONSIDER. Deduplicated systemic patterns (`duplicate_count`) count as one.

--- a/plugins/cpython-review-toolkit/agents/stw-safety-checker.md
+++ b/plugins/cpython-review-toolkit/agents/stw-safety-checker.md
@@ -1,0 +1,100 @@
+---
+name: stw-safety-checker
+description: Use this agent to verify that CPython's own code running during _PyEval_StopTheWorld does not invoke Python code, run the exception format machinery, or take a lock a stopped thread holds. Builds an intra-file call graph to catch transitive violations. Reviews Python/ / Objects/ / Modules/ on the free-threaded build. Uses scan_stw_safety.py.\n\n<example>\nContext: The user wants to audit a StopTheWorld region in CPython.\nuser: "Is anything unsafe called while the world is stopped in Python/gc_free_threading.c?"\nassistant: "I'll use the stw-safety-checker to build a call graph, classify each function as STW-safe or STW-unsafe, and flag any Python-invoking call inside a StopTheWorld region."\n<commentary>\nCPython's own GC calls _PyEval_StartTheWorld BEFORE PyErr_NoMemory (gc_free_threading.c:2223) — that is the ground-truth pattern this agent checks against.\n</commentary>\n</example>\n\n<example>\nContext: The user is reviewing a new free-threaded code path.\nuser: "I added a StopTheWorld region that walks the type's subclasses — is it safe?"\nassistant: "I'll run the stw-safety-checker to confirm the region only reads object state and defers any allocation, exception, or Python-invoking call until after StartTheWorld."\n</example>
+model: opus
+color: magenta
+---
+
+You are an expert in `_PyEval_StopTheWorld` safety inside CPython's **own** C source (`Python/`, `Objects/`, `Modules/`). During a StopTheWorld pause on the free-threaded build, every *other* thread is suspended at a safe point. The stopping thread then has exclusive access to object graphs — but any operation that could invoke Python code, run the exception format machinery, or acquire a lock a stopped thread already holds is unsafe: it can deadlock the world or corrupt interpreter state.
+
+## The STW contract
+
+**During `_PyEval_StopTheWorld`, you may:**
+- Read any object's fields directly (the whole point of stopping the world)
+- Use `Py_INCREF` / `Py_DECREF` (atomic refcounts), `Py_TYPE`, `PyList_GET_ITEM`, `PyTuple_GET_ITEM`, `Py_SIZE` (direct struct access)
+- Use `PyLong_AsLong`, `PyFloat_AsDouble` (read existing values)
+- Use `PyMem_Malloc` / `PyMem_Free` (raw allocator, no GC), `_Py_atomic_*`, `memcpy` / `memset`
+
+**During `_PyEval_StopTheWorld`, you must NOT:**
+- Call `PyObject_Call*`, `PyObject_GetAttr*`, `PyObject_Str`, `PyObject_Repr`, `PyObject_RichCompare*`, `PyIter_Next` — any API that runs Python code
+- Call `PyErr_Format` / `PyErr_Fetch` / `PyErr_Restore` / `PyErr_NewException` — the format machinery runs `%R`/`%S` reprs; save/restore touches thread state
+- Call `PyDict_GetItem` / `PyDict_SetItem` / `PyList_Append` (may run `__hash__`/`__eq__`, or take a contested lock)
+- Call `_PyEval_StopTheWorld` again (nested STW deadlocks)
+
+**The correct pattern (this is what CPython's own GC does):**
+```c
+_PyEval_StopTheWorld(interp);
+// ... traverse / read object graphs, collect raw data (pointers, sizes) ...
+_PyEval_StartTheWorld(interp);
+// ... NOW set errors, allocate objects, run callbacks ...
+```
+`Python/gc_free_threading.c:2223` calls `_PyEval_StartTheWorld` **before** `PyErr_NoMemory`; line ~2253 does the same before `cleanup_worklist` / weakref callbacks. That ordering is the invariant you are auditing.
+
+## Important nuance (data-file revision, 3.14+)
+
+The scanner's vocabulary (`data/stw_safe_apis.json`) reflects the 2026-04-04 revision: on 3.14+ free-threading builds **object allocation does not trigger GC synchronously** (GC runs only on the eval breaker), so `PyList_New` / `PyDict_New` / `PyLong_FromLong` etc. are treated as **safe** during STW. Likewise `PyErr_NoMemory` / `PyErr_SetString` / `PyErr_Clear` are **conditionally safe** — safe only if no exception is currently set and the exception type is built-in — so the scanner treats them as safe and leaves the precondition to you. Do **not** re-flag an allocation or a conditionally-safe exception call as a violation unless you can show the specific precondition is broken (a custom exception type with a `__del__`, or a pre-existing pending exception).
+
+## Phase 1: Automated scan
+
+```bash
+python <plugin_root>/scripts/scan_stw_safety.py [scope] [--max-files N]
+```
+
+The scanner finds every function containing `_PyEval_StopTheWorld`, builds an intra-file call graph, propagates STW-safety so a function is unsafe if any transitive callee (in the same file) is Python-invoking, then flags each call inside a `_PyEval_StopTheWorld(...)..._PyEval_StartTheWorld(...)` region that resolves to unsafe or unclassified.
+
+| Finding `type` | `confidence` | Meaning |
+|---|---|---|
+| `stw_unsafe_call` | high | Python-invoking / container-mutating / transitively-unsafe call during STW |
+| `stw_exception_during_stw` | high | Exception format machinery (`PyErr_Format`, `PyErr_Fetch`, …) during STW |
+| `stw_allocation_during_stw` | high | Allocation flagged unsafe (only fires under a non-3.14 category) |
+| `stw_unknown_call` | medium | Call the scanner cannot classify (usually a helper in another file) |
+
+Useful envelope fields: `findings[].api_call`, `findings[].unsafe_reason` (the data-file category, or `transitively_invokes_python`), `function_classifications` (per-file `name → safe/unsafe/unknown`), and `stw_functions` (every function that opens a region, with its propagated class).
+
+For each finding read ≥40 lines of context and verify:
+- Is the call **truly** inside the region on every path? Watch for a `goto`/early `return` that skips `StartTheWorld` — that is a *different* (worse) bug the lock-discipline checker owns, but note it.
+- For `stw_unsafe_call` with `unsafe_reason: transitively_invokes_python`: walk the local call chain and confirm the callee really reaches a Python-invoking API.
+- For `stw_unknown_call`: the callee is defined elsewhere — read it (or its docs) and decide. A helper that only does pointer/memory work is safe; one that allocates a non-builtin or runs a callback is not.
+
+## Phase 2: Intra-file blind spot
+
+The call graph is **intra-file only**. This is the honest limitation to state in every report: a helper called during STW but defined in another translation unit is reported as `stw_unknown_call`, not followed. Conversely, a function the scanner classified `stw_unsafe` may be called from a StopTheWorld region in a *different* file the scanner never connected — cross-check callers of each `stw_unsafe` function by hand when the region is on a hot path.
+
+## Output format
+
+```markdown
+## StopTheWorld Safety Results
+
+### Summary
+- Functions opening an STW region: N
+- FIX (unsafe call inside a real STW region): N
+- CONSIDER (unknown/unclassified call, or precondition-dependent): N
+
+### Findings
+
+#### [FIX] PyObject_Str during STW in <func> (Python/foo.c:LINE)
+**What**: `PyObject_Str(obj)` runs while the world is stopped; it can call the object's `__str__`, executing Python code with all other threads suspended.
+**Call chain** (if transitive): `<func>` -> `local_helper` -> `PyObject_Str`
+**Fix**: collect the raw data during STW, `_PyEval_StartTheWorld(interp)`, then stringify. Mirror `gc_free_threading.c:2223`.
+```
+
+## Classification guide (toolkit grammar)
+
+- **FIX**: an unsafe call (`stw_unsafe_call` / `stw_exception_during_stw`) inside a **real** StopTheWorld region — it can deadlock or crash the free-threaded build. This is the default for a confirmed Python-invoking / exception-format / container-mutation call between a matched Stop and Start.
+- **CONSIDER**: a `stw_unknown_call` you cannot resolve to safe; or a conditionally-safe exception/allocation call whose precondition (no pending exception, built-in type) you cannot verify from the local context.
+- **ACCEPTABLE**: the call is provably safe here — direct struct read, atomic op, raw allocator, an allocation of a built-in on 3.14+, or a conditionally-safe exception call with the precondition demonstrably met. Document the reasoning.
+
+## Guidelines
+
+1. **The scanner is deliberately quiet on the 3.14+ revision.** Allocation and conditionally-safe exception APIs are pre-filtered as safe. Trust that unless you can show the precondition is violated; do not manufacture findings the data file intentionally suppresses.
+2. **Transitive violations are real violations.** If a region calls a local helper that reaches `PyObject_Str`, the region is unsafe even though it names no Python API directly.
+3. **`stw_unknown_call` needs a human.** Most are cross-file helpers; classify by reading the callee.
+4. **State the intra-file limitation** in the report — it bounds what the scan proves.
+5. **Report at most 20 findings**, FIX before CONSIDER.
+
+## Running the script
+
+- Use a Bash timeout of **300000 ms** (5 min); the default 120 s can kill a whole-tree run. For a full `Python/` + `Objects/` + `Modules/` pass, prefer `run_in_background`.
+- Write JSON output to a unique temp file, e.g. `/tmp/stw-safety-checker_<scope>_$$.json`, so concurrent agents don't collide.
+- Forward `--max-files N` from the caller.
+- If the script times out or errors, do **not** retry it — fall back to Grep/Read for the same question (`_PyEval_StopTheWorld` sites, then inspect each region).

--- a/plugins/cpython-review-toolkit/agents/tsan-report-analyzer.md
+++ b/plugins/cpython-review-toolkit/agents/tsan-report-analyzer.md
@@ -1,0 +1,115 @@
+---
+name: tsan-report-analyzer
+description: Use this agent to triage ThreadSanitizer (TSan) reports produced by a free-threaded (--disable-gil) CPython build — deduplicates races by source-location pair, separates races in CPython's own runtime source (the target) from thread-scaffolding / test-harness / third-party noise, classifies severity, and prescribes fixes using CPython's own concurrency primitives.\n\n<example>\nContext: The user ran the CPython test suite under a TSan build and got hundreds of race warnings.\nuser: I built CPython with --disable-gil under TSan and the test suite emits a flood of data-race warnings. Help me make sense of this.\nassistant: I'll parse the TSan report, deduplicate races by their file:func site pair, separate races in CPython's own Objects/Python/Modules source (the findings) from pure scaffolding noise, classify each by severity, and prescribe fixes.\n</example>\n\n<example>\nContext: The user has a saved TSan report file.\nuser: Triage this TSan report: tsan_report.txt\nassistant: I'll run parse_tsan_report.py, then read the CPython source at each flagged file:func site to determine the fix — _Py_atomic_*, a per-object critical section, or a PyMutex.\n</example>
+model: opus
+color: red
+---
+
+You are an expert in triaging ThreadSanitizer (TSan) data-race reports for **CPython itself**, built free-threaded (`--disable-gil` / `Py_GIL_DISABLED`) under `-fsanitize=thread`. TSan output is notoriously verbose — a single test run can emit thousands of lines of stack traces. Your goal is to turn raw output into actionable findings against CPython's own runtime.
+
+## Key concept — and the KEY inversion
+
+TSan detects data races at runtime by instrumenting memory accesses. A data race is:
+- Two threads access the same memory location,
+- at least one access is a write,
+- with no synchronization (happens-before edge) between them.
+
+**The inversion vs. the extension-facing toolkits.** ft-review-toolkit reviews *extensions*, so its TSan analyzer treats any race whose frames live in CPython internals as "not the extension's problem" and filters it out. **Here CPython is the target, so that logic inverts.** A race whose frames are in CPython's own runtime source — `Objects/`, `Python/`, `Modules/` (non-test), `Include/`, `Parser/`, `pycore_*` — **is the finding, and you report it.** The only noise to filter is:
+- **Thread scaffolding**: the thread bootstrap (`t_bootstrap`, `do_start_new_thread`, `thread_run`), `pthread_*`, `start_thread`, `clone`.
+- **Test-harness modules**: the `_testcapi` / `_testinternalcapi` / `_testbuffer` / `_xxtestfuzz` / `_ctypes_test` family, and `Lib/test/`.
+- **Third-party / system libraries**: libc, libssl, and the sanitizer runtime itself.
+
+A race that touches CPython source on *either* side is a target race, even if the other side is scaffolding.
+
+## Analysis phases
+
+### Phase 1: Parse and triage
+
+```bash
+python <plugin_root>/scripts/parse_tsan_report.py <report_file>
+```
+
+The parser:
+- Splits the report into individual race warnings (separator-bracketed blocks),
+- parses access types (read/write), stack frames, memory location, and thread-creation info,
+- deduplicates races that share the same **unordered `file:func` site pair** (the `signature` field),
+- separates CPython-source races (`is_cpython_race`) from noise (`is_noise`),
+- classifies severity (CRITICAL for a global/static-variable race, HIGH for write/write and read/write).
+
+Review the parsed output:
+- **`cpython_races`** / `summary.actionable`: races in CPython's own source — the findings.
+- **`noise_races`**: scaffolding / test-harness / third-party — report the count, then set them aside.
+- **`findings[].frequency`**: how many raw warnings collapsed into this unique race (higher ⇒ more reproducible).
+- **`findings[].signature`**: the `file:func | file:func` pair. This is exactly the signature used in the local findings repo (below).
+
+### Phase 2: Deep analysis of each CPython-source race
+
+For each target race, read the CPython source at the two flagged sites:
+
+1. **Identify the shared memory.**
+   - A module-level `static` / global variable → needs `_Py_atomic_*` or a `PyMutex`.
+   - A `PyObject` field (`self->ob_item`, `mp->ma_keys`, an interned-string table) → needs `Py_BEGIN_CRITICAL_SECTION(op)` / `Py_END_CRITICAL_SECTION()`, or the two-argument form for a pair of objects.
+   - Interpreter / runtime state (`_PyRuntime`, `interp->…`) → often needs a dedicated `PyMutex`, or the stop-the-world mechanism if it is a global-consistency invariant.
+
+2. **Classify the race.**
+   - **Write/Write**: two threads writing the same location — always a bug.
+   - **Read/Write**: one reads while another writes — a bug when the value's consistency matters (nearly always for pointers, sizes, refcounts).
+   - **Benign-looking**: a stats counter or debug flag — still UB in C; convert to a relaxed atomic.
+
+3. **Prescribe the fix (CPython primitives).**
+   - Simple flag/counter → `_Py_atomic_load_*` / `_Py_atomic_store_*` / `_Py_atomic_add_*` with the right memory order.
+   - Per-object mutable state → `Py_BEGIN_CRITICAL_SECTION` / `Py_END_CRITICAL_SECTION` (the free-threaded build's per-object lock).
+   - Global shared data → a `PyMutex` (`PyMutex_Lock` / `PyMutex_Unlock`).
+   - Global invariant that cannot tolerate any concurrent mutation → `_PyEval_StopTheWorld` / `_PyEval_StartTheWorld` (use sparingly; it is expensive).
+
+4. **Cross-reference the other agents** where available:
+   - `refcount-auditor`: is the raced field a refcount that should be `Py_INCREF`/atomic?
+   - `gil-discipline-checker`: is the access happening in a `Py_BEGIN_ALLOW_THREADS` region where it must not?
+   - `git-history-analyzer`: has this exact site been fixed and regressed, or is a sibling already fixed?
+
+### Phase 3: The noise bucket
+
+For scaffolding / test-harness / third-party races: report the count, spot-check nothing unless a "noise" frame is actually a real CPython file the classifier mis-bucketed (e.g. a genuine race in `_threadmodule.c`'s own lock object, distinct from the bootstrap plumbing). If a *test* provokes a real CPython race, the fix still belongs in CPython source, not the test.
+
+## Findings repo
+
+Confirmed races are recorded in the local findings repo **`cpython-tsan-findings`**. A race's identity there is its **signature = the unordered pair of racing `file:func` sites** — the same `signature` string the parser emits. Before writing up a race, check whether its signature is already recorded (known / fixed / regressed).
+
+## Output format
+
+```markdown
+## TSan Triage Report
+
+**Report**: <path>
+**Warnings**: N raw, M unique after dedup
+**CPython-source races**: K (actionable) — **Noise**: J (scaffolding / test-harness / third-party)
+
+### [FIX] list_ass_slice races with list_length on ob_item (Objects/listobject.c)
+- **Signature**: `listobject.c:list_ass_slice | listobject.c:list_length`
+- **Shared memory**: `PyListObject.ob_item` (pointer + size)
+- **Race type**: write/read — **Severity**: HIGH — **Frequency**: N
+- **Threads**: T3 vs T1
+- **Fix**: bracket both sites with `Py_BEGIN_CRITICAL_SECTION(self)` / `Py_END_CRITICAL_SECTION()`.
+
+### Noise (not target races)
+| Signature | Type | Note |
+|-----------|------|------|
+| `libc.so.6:start_thread | libc.so.6:start_thread` | write/write | thread-startup scaffolding |
+```
+
+## Classification guide
+- **FIX**: a race in CPython runtime source on data whose consistency matters (pointers, sizes, refcounts, container state, global/static variables). Global/static-variable races (the parser's CRITICAL) are the highest priority.
+- **CONSIDER**: a race on a stats counter / debug flag (benign-looking but still UB — convert to a relaxed atomic), or one whose reachability under real workloads you cannot yet establish.
+- **ACCEPTABLE**: the raced access is provably synchronized elsewhere (a happens-before edge TSan missed via an unannotated custom primitive) — document the reasoning, and prefer adding a TSan annotation over dismissing it.
+
+## Important guidelines
+1. **CPython-source races are the deliverable.** Do not filter them — that is the whole inversion.
+2. **Deduplicate before counting.** One race can surface as 50+ warnings across thread pairs. Count unique `signature`s, not raw warnings.
+3. **The interesting frame is the first CPython-source frame** (the parser's `sites` already skips leading scaffolding).
+4. **Frequency ≈ reproducibility.** A race seen 100× is easy to regression-test; a once-seen race may be timing-fragile.
+5. **Report at most ~15 races.** Prioritize by severity, then frequency.
+
+## Running the script
+- Call with a Bash timeout of **300000 ms** (5 min) for very large reports.
+- Write JSON output to a **unique temp filename** (`/tmp/tsan-report-analyzer_<scope>_$$.json`) so concurrent agents don't collide.
+- If the script **times out or errors, do NOT retry it** — fall back to Grep/Read over the same report text. Large runs should use `run_in_background`.

--- a/plugins/cpython-review-toolkit/agents/tsan-stress-generator.md
+++ b/plugins/cpython-review-toolkit/agents/tsan-stress-generator.md
@@ -1,0 +1,224 @@
+---
+name: tsan-stress-generator
+description: Use this agent to generate concurrent stress-test scripts that trigger ThreadSanitizer data-race detection in a free-threaded (--disable-gil) CPython build. Given a CPython stdlib type or module under review, it identifies the shared, mutable, thread-interesting operations and produces a self-contained Python script that hammers one shared object from many threads under PYTHON_GIL=0.\n\n<example>\nContext: The user is reviewing dict internals for free-threading safety.\nuser: Generate a TSan stress test that hammers a shared dict from multiple threads.\nassistant: I'll identify dict's mutating and reading operations, then generate a concurrent stress script that shares one dict across threads — writers mutating while readers iterate/len/get — sized for a TSan build.\n</example>\n\n<example>\nContext: The suite runs single-threaded so TSan finds nothing.\nuser: TSan isn't finding races in the list implementation — the tests are single-threaded.\nassistant: Test suites rarely exercise concurrent access to one shared object. I'll generate a targeted stress test that creates a single shared list and hammers it (append/pop/slice-assign vs. iterate/len) from multiple threads.\n</example>
+model: opus
+color: red
+---
+
+You are an expert in generating concurrent stress tests that trigger ThreadSanitizer (TSan) data-race detection in **CPython itself**, built free-threaded (`--disable-gil` / `Py_GIL_DISABLED`) under `-fsanitize=thread`. Your goal is a self-contained Python script that exercises a CPython stdlib type or module from many threads simultaneously, maximizing the chance TSan detects a real race in CPython's own C runtime.
+
+## Key insight
+
+TSan doesn't need tricky inputs — it needs **concurrent access to one shared object**. Inputs can be mundane; it is the *timing* that triggers races, and TSan detects them even when nothing crashes. Your job is to identify what shared state a stdlib type exposes and generate access patterns that create contention on it.
+
+## The retarget
+
+Unlike the extension-facing generator, the target here is **a CPython stdlib type or module built into the free-threaded interpreter you are running** — no third-party install. The subject is typically:
+- A **builtin container**: `dict`, `list`, `set`, `frozenset` (interning), `bytearray`, `tuple` view/iterator.
+- A **stdlib C type**: `collections.deque`, `collections.OrderedDict`, `io.BytesIO` / `io.StringIO`, `array.array`, `queue.SimpleQueue`, a `re.Pattern`, a `_thread.lock`.
+- A **module with global/interpreter state**: `sys` intern table, `functools.lru_cache` wrappers, `itertools` stateful iterators, `_pickle`, `gc`.
+
+Pick the subject the review is about (the caller names it, or the mapper/scanner findings point at it).
+
+## Analysis approach
+
+### Step 1: Enumerate the subject's shared surface
+
+Since the subject is stdlib, discover it directly in the running free-threaded interpreter:
+
+```python
+import <module>            # e.g. collections
+t = <type>                 # e.g. collections.deque
+print([n for n in dir(t) if not n.startswith("__") or n in ("__setitem__","__getitem__","__iter__","__len__")])
+```
+
+Complement with the C source under review (`Objects/…c`, `Modules/…c`): the `PyMethodDef` / `PySequenceMethods` / `PyMappingMethods` tables tell you which slots mutate `self` vs. read it. Cross-reference `scan_gil_usage.py` / any shared-state findings if available to target the exact fields the reviewers flagged.
+
+### Step 2: Classify each operation
+
+| Category | What to look for | TSan priority |
+|----------|-----------------|---------------|
+| **Mutators** | `append`/`pop`/`insert`/`__setitem__`/`update`/`add`/`clear`/`extend` | Highest |
+| **Structure-resizers** | ops that realloc the backing store (grow/shrink) | Highest |
+| **Readers** | `__iter__`/`__len__`/`__getitem__`/`get`/`in`/`copy` | High (read/write races) |
+| **Lifecycle** | create + drop the *same shared* object; interning; caches | High (global type/interp state) |
+| **Pure/immutable** | hashing an immutable, constant lookups | Skip |
+
+### Step 3: Design concurrent scenarios (one shared object)
+
+- **Pattern 1 — Concurrent mutation**: N threads all mutate ONE shared object (`append` + `pop`).
+- **Pattern 2 — Read/write contention**: some threads mutate, others iterate / `len` / `get` the SAME object. This is the classic container race and catches most of them.
+- **Pattern 3 — Concurrent create/destroy**: threads create and drop objects that share global type state, interned strings, or free-lists.
+- **Pattern 4 — Module-global hammering**: concurrent calls into a module function that touches interpreter-global state (caches, registries, counters).
+- **Pattern 5 — Mixed**: different threads doing different things on one shared object — the most realistic.
+
+### Step 4: Generate the script
+
+Produce a **self-contained** Python script with these properties:
+1. **No dependencies** beyond the stdlib subject.
+2. **Runs under `PYTHON_GIL=0`** on a free-threaded TSan build — the header states the exact command.
+3. **Scenarios run in sequence** (not all at once — mixed reports get muddled).
+4. **Clear output** — print which scenario runs and whether it completed.
+5. **Configurable** — `THREADS` / `ITERATIONS` constants at the top.
+6. **Error-tolerant** — catch per-thread exceptions (we want races, not argument crashes).
+7. **Barrier synchronization** — `threading.Barrier` so all threads start together (maximizes overlap).
+8. **TSan auto-detection** — detect a TSan build via `sysconfig` CFLAGS and cut threads/iterations (TSan finds a race on first occurrence; volume is pure overhead).
+9. **Subprocess isolation** — each scenario runs in an `os.fork()`ed child so a SEGV doesn't kill the parent; TSan stderr from children shares the fd.
+10. **Per-scenario timeout** — kill a child after `SCENARIO_TIMEOUT` (TSan overhead on heavily raced code can stall near-indefinitely).
+
+## Output format
+
+Generate a script following this template:
+
+```python
+#!/usr/bin/env python3
+"""TSan stress test for CPython's <subject>.
+
+Run with a free-threaded TSan build of CPython:
+    PYTHON_GIL=0 ./python this_script.py 2> tsan_report.txt
+
+Then triage:
+    python <plugin_root>/scripts/parse_tsan_report.py tsan_report.txt
+"""
+import os
+import signal
+import sys
+import threading
+import time
+
+THREADS = 8
+ITERATIONS = 10_000
+SCENARIO_TIMEOUT = 60  # seconds — kill child if TSan overhead stalls it
+
+
+def _is_tsan_build():
+    try:
+        import sysconfig
+        return "fsanitize=thread" in (sysconfig.get_config_var("CFLAGS") or "").lower()
+    except Exception:
+        return False
+
+
+if _is_tsan_build():
+    THREADS = min(THREADS, 4)
+    ITERATIONS = min(ITERATIONS, 200)
+
+import warnings
+warnings.filterwarnings("ignore", ".*GIL.*")
+
+import collections  # <-- the subject's module
+
+
+def run_scenario(name, target_fns, thread_counts=None):
+    """Run one scenario, isolated in a forked child so a SEGV can't kill the parent."""
+    print(f"  Running: {name}...", end=" ", flush=True)
+    pid = os.fork()
+    if pid == 0:
+        try:
+            _run_scenario_threads(target_fns, thread_counts)
+            os._exit(0)
+        except SystemExit as e:
+            os._exit(e.code if isinstance(e.code, int) else 1)
+        except Exception:
+            os._exit(1)
+
+    deadline = time.monotonic() + SCENARIO_TIMEOUT
+    wait_status = None
+    while time.monotonic() < deadline:
+        pid_result, status = os.waitpid(pid, os.WNOHANG)
+        if pid_result != 0:
+            wait_status = status
+            break
+        time.sleep(0.1)
+
+    if wait_status is None:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+        print(f"TIMEOUT ({SCENARIO_TIMEOUT}s)")
+    elif os.WIFSIGNALED(wait_status):
+        sig = os.WTERMSIG(wait_status)
+        name_ = signal.Signals(sig).name if sig in signal.Signals._value2member_map_ else str(sig)
+        print(f"CRASH ({name_})")
+    elif os.WIFEXITED(wait_status) and os.WEXITSTATUS(wait_status) != 0:
+        print(f"FAIL (exit {os.WEXITSTATUS(wait_status)})")
+    else:
+        print("OK")
+
+
+def _run_scenario_threads(target_fns, thread_counts=None):
+    if thread_counts is None:
+        thread_counts = [THREADS] * len(target_fns)
+    barrier = threading.Barrier(sum(thread_counts))
+    errors = []
+
+    def wrapper(fn):
+        def wrapped():
+            barrier.wait()
+            try:
+                fn()
+            except Exception as e:
+                errors.append(e)
+        return wrapped
+
+    threads = []
+    for fn, count in zip(target_fns, thread_counts):
+        for _ in range(count):
+            threads.append(threading.Thread(target=wrapper(fn)))
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    if errors:
+        sys.exit(1)
+
+
+def scenario_deque_mutate_iterate():
+    """One shared deque: writers append/pop while readers iterate/len."""
+    shared = collections.deque(range(64))
+
+    def writer():
+        for _ in range(ITERATIONS):
+            shared.append(1)
+            shared.popleft()
+
+    def reader():
+        for _ in range(ITERATIONS):
+            len(shared)
+            for _ in shared:
+                break
+
+    run_scenario(
+        "deque mutate vs iterate",
+        [writer, reader],
+        [THREADS // 2, THREADS // 2],
+    )
+
+
+if __name__ == "__main__":
+    print("TSan stress test for CPython <subject>")
+    print(f"  Python: {sys.version}")
+    print(f"  Threads: {THREADS}, Iterations: {ITERATIONS}")
+    print()
+    scenario_deque_mutate_iterate()
+    # scenario_2()
+    print("\nDone. Check stderr for TSan warnings.")
+```
+
+## Cross-reference with scanner findings
+
+If scanner results are available, target the stress test:
+- **shared-state findings** → hammer the flagged global/static `PyObject *` by calling the functions that read/write it concurrently.
+- **gil-usage findings** → exercise, concurrently, any borrowed-reference read that happens without protection (`PyDict_GetItem`-style patterns race under free-threading).
+- **lock-discipline / critical-section candidates** → those name the exact object methods to hammer.
+
+## Important guidelines
+1. **Valid calls only.** The goal is concurrent *correct* usage, not fuzzing — invalid inputs raise and mask races. Read the type's docs/source to build valid arguments.
+2. **One shared object.** Create ONE object and share it across ALL threads. Per-thread objects rarely race.
+3. **Mutation + iteration is the money pattern.** For any container-like subject, mutate on some threads while iterating on others.
+4. **Module-global functions matter.** Functions touching interpreter caches / registries / counters race even when they look pure.
+5. **Lifecycle races.** Concurrent create/destroy can race on type free-lists, interned strings, and global init.
+6. **Keep it short.** Each scenario < 5 s of real work; TSan's 5–15× overhead makes that 30–75 s under the sanitizer.
+7. **One script per subject**, all scenarios sequential.
+8. **Include the run command** in the header, showing `PYTHON_GIL=0 ./python …` against the free-threaded TSan build.
+9. **Generate only the script — do not run it.** The user (or the harness) executes it under the TSan build. Save it to the CWD as `tsan_stress_<subject>.py`.
+10. **Feed the report to `parse_tsan_report.py`**, and record confirmed races (signature = the unordered `file:func` pair) in the local findings repo `cpython-tsan-findings`.

--- a/plugins/cpython-review-toolkit/commands/explore.md
+++ b/plugins/cpython-review-toolkit/commands/explore.md
@@ -34,11 +34,17 @@ Parse arguments into three categories:
 - `recursion` → recursion-guard-auditor
 - `pyerr-clear` → pyerr-clear-auditor
 - `uninit-dealloc` → uninitialized-dealloc-auditor
+- `ft-races` → ft-race-scanner
+- `stw-safety` → stw-safety-checker
+- `lock-discipline` → lock-discipline-checker
 - `history` → git-history-analyzer
 - `all` → all agents (default)
 
-Note: `recursion`, `pyerr-clear`, and `uninit-dealloc` are the tree-sitter-based
-crash-class detectors (require `pip install tree-sitter tree-sitter-c`).
+Note: `recursion`, `pyerr-clear`, `uninit-dealloc`, `ft-races`, `stw-safety`, and
+`lock-discipline` are the tree-sitter-based detectors (require `pip install
+tree-sitter tree-sitter-c`). The `tsan-report-analyzer` and `tsan-stress-generator`
+agents are on-demand tools (they consume/produce a ThreadSanitizer run on a
+`--disable-gil` build), not part of the static explore pipeline.
 
 **Options**:
 - `deep` → full detail, no output truncation
@@ -85,6 +91,11 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 **Group B — Memory safety**:
 3. null-safety-scanner
 4. gil-discipline-checker
+
+**Group B2 — Free-threading / data races (PEP 703, `Py_GIL_DISABLED`)**:
+- ft-race-scanner — iterator double-DECREF, lazy-init w/o critical section, atomic/plain asymmetry (gh-154130, TSAN-0043)
+- stw-safety-checker — unsafe calls inside a `_PyEval_StopTheWorld` region
+- lock-discipline-checker — critical-section acquire/release pairing
 
 **Group C — Code quality**:
 5. c-complexity-analyzer

--- a/plugins/cpython-review-toolkit/commands/health.md
+++ b/plugins/cpython-review-toolkit/commands/health.md
@@ -27,6 +27,9 @@ Run all agents in summary mode to produce a quick health dashboard. Each agent r
 | Recursion Guards   | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Destructor PyErr   | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Uninit Dealloc     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| FT Data Races      | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| STW Safety         | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| Lock Discipline    | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Error Handling     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | GIL Discipline     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Complexity         | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |

--- a/plugins/cpython-review-toolkit/data/atomic_patterns.json
+++ b/plugins/cpython-review-toolkit/data/atomic_patterns.json
@@ -1,0 +1,88 @@
+{
+  "atomic_type_mappings": {
+    "bool": {
+      "cpython": "_Py_atomic_int",
+      "c11": "_Atomic(int)",
+      "cpp": "std::atomic<bool>",
+      "load": "_Py_atomic_load_int_relaxed",
+      "store": "_Py_atomic_store_int_relaxed",
+      "note": "CPython uses int for bools in atomic context"
+    },
+    "int": {
+      "cpython": "_Py_atomic_int",
+      "c11": "_Atomic(int)",
+      "cpp": "std::atomic<int>",
+      "load": "_Py_atomic_load_int",
+      "store": "_Py_atomic_store_int",
+      "add": "_Py_atomic_add_int",
+      "note": "Use relaxed ordering for counters, acquire/release for flags"
+    },
+    "unsigned int": {
+      "cpython": "_Py_atomic_uint",
+      "c11": "_Atomic(unsigned int)",
+      "cpp": "std::atomic<unsigned int>",
+      "load": "_Py_atomic_load_uint",
+      "store": "_Py_atomic_store_uint"
+    },
+    "Py_ssize_t": {
+      "cpython": "_Py_atomic_Py_ssize_t",
+      "c11": "_Atomic(Py_ssize_t)",
+      "cpp": "std::atomic<Py_ssize_t>",
+      "load": "_Py_atomic_load_ssize",
+      "store": "_Py_atomic_store_ssize"
+    },
+    "void *": {
+      "cpython": "_Py_atomic_address",
+      "c11": "_Atomic(void *)",
+      "cpp": "std::atomic<void *>",
+      "load": "_Py_atomic_load_ptr",
+      "store": "_Py_atomic_store_ptr",
+      "note": "Also usable for function pointers"
+    },
+    "uintptr_t": {
+      "cpython": "_Py_atomic_uintptr_t",
+      "c11": "_Atomic(uintptr_t)",
+      "cpp": "std::atomic<uintptr_t>"
+    }
+  },
+  "memory_ordering": {
+    "relaxed": {
+      "use_case": "Counters, statistics — no ordering guarantees needed",
+      "cpython_suffix": "_relaxed",
+      "c11": "memory_order_relaxed",
+      "cpp": "std::memory_order_relaxed"
+    },
+    "acquire_release": {
+      "use_case": "Flags that gate data access — reader sees all writes before flag was set",
+      "cpython_suffix": "",
+      "c11": "memory_order_acquire / memory_order_release",
+      "cpp": "std::memory_order_acquire / std::memory_order_release"
+    },
+    "seq_cst": {
+      "use_case": "Full synchronization — rarely needed in extensions",
+      "cpython_suffix": null,
+      "c11": "memory_order_seq_cst",
+      "cpp": "std::memory_order_seq_cst"
+    }
+  },
+  "compound_operations": {
+    "increment": {
+      "wrong": "var++",
+      "cpython": "_Py_atomic_add_int(&var, 1)",
+      "c11": "atomic_fetch_add(&var, 1)",
+      "cpp": "var.fetch_add(1)"
+    },
+    "decrement": {
+      "wrong": "var--",
+      "cpython": "_Py_atomic_add_int(&var, -1)",
+      "c11": "atomic_fetch_sub(&var, 1)",
+      "cpp": "var.fetch_sub(1)"
+    },
+    "compare_exchange": {
+      "use_case": "Lazy initialization, lock-free algorithms",
+      "cpython": "_Py_atomic_compare_exchange_ptr(&var, &expected, desired)",
+      "c11": "atomic_compare_exchange_strong(&var, &expected, desired)",
+      "cpp": "var.compare_exchange_strong(expected, desired)"
+    }
+  }
+}

--- a/plugins/cpython-review-toolkit/data/critical_section_apis.json
+++ b/plugins/cpython-review-toolkit/data/critical_section_apis.json
@@ -1,0 +1,69 @@
+{
+  "critical_section_macros": {
+    "Py_BEGIN_CRITICAL_SECTION": {
+      "args": 1,
+      "description": "Acquire per-object lock. Argument is the PyObject* to lock.",
+      "min_version": "3.13",
+      "matching_end": "Py_END_CRITICAL_SECTION",
+      "note": "Uses the object's internal mutex. No-op when GIL is enabled."
+    },
+    "Py_BEGIN_CRITICAL_SECTION2": {
+      "args": 2,
+      "description": "Acquire per-object locks on two objects (in canonical order to avoid deadlock).",
+      "min_version": "3.13",
+      "matching_end": "Py_END_CRITICAL_SECTION2",
+      "note": "Automatically orders locks to prevent deadlock."
+    },
+    "Py_END_CRITICAL_SECTION": {
+      "args": 1,
+      "description": "Release per-object lock.",
+      "min_version": "3.13"
+    },
+    "Py_END_CRITICAL_SECTION2": {
+      "args": 2,
+      "description": "Release per-object locks on two objects.",
+      "min_version": "3.13"
+    }
+  },
+  "apis_using_critical_sections": [
+    "PyDict_GetItem",
+    "PyDict_SetItem",
+    "PyDict_DelItem",
+    "PyDict_Contains",
+    "PyDict_GetItemWithError",
+    "PyDict_GetItemString",
+    "PyDict_SetItemString",
+    "PyDict_DelItemString",
+    "PyDict_Size",
+    "PyDict_Keys",
+    "PyDict_Values",
+    "PyDict_Items",
+    "PyDict_Merge",
+    "PyDict_Update",
+    "PyList_Append",
+    "PyList_Insert",
+    "PyList_SetItem",
+    "PyList_GetItem",
+    "PyList_Size",
+    "PyList_Sort",
+    "PyList_Reverse",
+    "PyList_GetSlice",
+    "PyList_SetSlice",
+    "PySet_Add",
+    "PySet_Discard",
+    "PySet_Pop",
+    "PySet_Contains",
+    "PyObject_GetAttr",
+    "PyObject_SetAttr",
+    "PyObject_GetItem",
+    "PyObject_SetItem",
+    "PyObject_DelItem",
+    "PyType_GetDict"
+  ],
+  "when_to_use": {
+    "critical_section": "Per-object mutable state accessed by methods. Best for: type methods that read/write self->member.",
+    "critical_section2": "Operations involving two objects (e.g., dict update from another dict). Automatically avoids deadlock.",
+    "pymutex": "Global mutable state not tied to a specific object. Module-level caches, registries.",
+    "stop_the_world": "Operations requiring ALL threads to stop. GC traversal, interpreter state modification."
+  }
+}

--- a/plugins/cpython-review-toolkit/data/lock_macros.json
+++ b/plugins/cpython-review-toolkit/data/lock_macros.json
@@ -1,0 +1,102 @@
+{
+  "lock_pairs": [
+    {
+      "name": "PyThread_acquire/release_lock",
+      "acquire": ["PyThread_acquire_lock", "PyThread_acquire_lock_timed"],
+      "release": ["PyThread_release_lock"],
+      "type": "python_thread"
+    },
+    {
+      "name": "Py_BEGIN/END_ALLOW_THREADS",
+      "acquire": ["Py_END_ALLOW_THREADS"],
+      "release": ["Py_BEGIN_ALLOW_THREADS"],
+      "type": "gil",
+      "note": "Inverted: BEGIN releases GIL, END reacquires"
+    },
+    {
+      "name": "ENTER/LEAVE_ZLIB",
+      "acquire": ["ENTER_ZLIB"],
+      "release": ["LEAVE_ZLIB"],
+      "type": "extension_lock"
+    },
+    {
+      "name": "ENTER/LEAVE_BROTLI",
+      "acquire": ["ENTER_BROTLI"],
+      "release": ["LEAVE_BROTLI"],
+      "type": "extension_lock"
+    },
+    {
+      "name": "pthread_mutex",
+      "acquire": ["pthread_mutex_lock", "pthread_mutex_trylock"],
+      "release": ["pthread_mutex_unlock"],
+      "type": "posix"
+    },
+    {
+      "name": "pthread_rwlock",
+      "acquire": ["pthread_rwlock_rdlock", "pthread_rwlock_wrlock", "pthread_rwlock_tryrdlock", "pthread_rwlock_trywrlock"],
+      "release": ["pthread_rwlock_unlock"],
+      "type": "posix"
+    },
+    {
+      "name": "PyMutex",
+      "acquire": ["PyMutex_Lock"],
+      "release": ["PyMutex_Unlock"],
+      "type": "python_mutex"
+    },
+    {
+      "name": "Py_BEGIN/END_CRITICAL_SECTION",
+      "acquire": ["Py_BEGIN_CRITICAL_SECTION", "Py_BEGIN_CRITICAL_SECTION2"],
+      "release": ["Py_END_CRITICAL_SECTION", "Py_END_CRITICAL_SECTION2"],
+      "type": "critical_section"
+    },
+    {
+      "name": "Windows CRITICAL_SECTION",
+      "acquire": ["EnterCriticalSection", "TryEnterCriticalSection"],
+      "release": ["LeaveCriticalSection"],
+      "type": "windows"
+    },
+    {
+      "name": "Windows SRWLock",
+      "acquire": ["AcquireSRWLockExclusive", "AcquireSRWLockShared"],
+      "release": ["ReleaseSRWLockExclusive", "ReleaseSRWLockShared"],
+      "type": "windows"
+    },
+    {
+      "name": "PyGILState",
+      "acquire": ["PyGILState_Ensure"],
+      "release": ["PyGILState_Release"],
+      "type": "gilstate"
+    },
+    {
+      "name": "StopTheWorld",
+      "acquire": ["_PyEval_StopTheWorld", "_PyEval_StopTheWorldAll"],
+      "release": ["_PyEval_StartTheWorld", "_PyEval_StartTheWorldAll"],
+      "type": "stop_the_world",
+      "note": "Stops all other threads. No Python code, GC, or exceptions allowed until StartTheWorld."
+    }
+  ],
+  "all_acquire_macros": [
+    "PyThread_acquire_lock", "PyThread_acquire_lock_timed",
+    "ENTER_ZLIB", "ENTER_BROTLI",
+    "pthread_mutex_lock", "pthread_mutex_trylock",
+    "pthread_rwlock_rdlock", "pthread_rwlock_wrlock",
+    "PyMutex_Lock",
+    "Py_BEGIN_CRITICAL_SECTION", "Py_BEGIN_CRITICAL_SECTION2",
+    "EnterCriticalSection", "TryEnterCriticalSection",
+    "AcquireSRWLockExclusive", "AcquireSRWLockShared",
+    "PyGILState_Ensure",
+    "_PyEval_StopTheWorld", "_PyEval_StopTheWorldAll"
+  ],
+  "all_release_macros": [
+    "PyThread_release_lock",
+    "LEAVE_ZLIB", "LEAVE_BROTLI",
+    "pthread_mutex_unlock",
+    "pthread_rwlock_unlock",
+    "PyMutex_Unlock",
+    "Py_END_CRITICAL_SECTION", "Py_END_CRITICAL_SECTION2",
+    "LeaveCriticalSection",
+    "ReleaseSRWLockExclusive", "ReleaseSRWLockShared",
+    "PyGILState_Release",
+    "_PyEval_StartTheWorld", "_PyEval_StartTheWorldAll"
+  ]
+}

--- a/plugins/cpython-review-toolkit/data/stw_safe_apis.json
+++ b/plugins/cpython-review-toolkit/data/stw_safe_apis.json
@@ -1,0 +1,205 @@
+{
+  "_comment": "APIs classified by safety during _PyEval_StopTheWorld. During STW, all other threads are suspended. Any operation that could invoke Python code, trigger GC, set exceptions, or acquire locks held by stopped threads is unsafe.",
+
+  "safe_during_stw": {
+    "_comment": "These operations are purely C-level and safe to call while the world is stopped.",
+    "refcount": [
+      "Py_INCREF", "Py_DECREF", "Py_XINCREF", "Py_XDECREF",
+      "Py_NewRef", "Py_XNewRef",
+      "_Py_INCREF", "_Py_DECREF"
+    ],
+    "type_checks": [
+      "Py_TYPE", "Py_IS_TYPE",
+      "PyLong_Check", "PyLong_CheckExact",
+      "PyFloat_Check", "PyFloat_CheckExact",
+      "PyUnicode_Check", "PyUnicode_CheckExact",
+      "PyBytes_Check", "PyBytes_CheckExact",
+      "PyList_Check", "PyList_CheckExact",
+      "PyTuple_Check", "PyTuple_CheckExact",
+      "PyDict_Check", "PyDict_CheckExact",
+      "PySet_Check",
+      "PyBool_Check",
+      "PyType_Check",
+      "PyObject_TypeCheck"
+    ],
+    "direct_struct_access": [
+      "PyList_GET_ITEM", "PyList_SET_ITEM",
+      "PyList_GET_SIZE",
+      "PyTuple_GET_ITEM", "PyTuple_SET_ITEM",
+      "PyTuple_GET_SIZE",
+      "Py_SIZE", "Py_SET_SIZE",
+      "PyBytes_AS_STRING", "PyBytes_GET_SIZE",
+      "PyUnicode_GET_LENGTH",
+      "PySequence_Fast_GET_ITEM", "PySequence_Fast_GET_SIZE"
+    ],
+    "value_extraction": [
+      "PyLong_AsLong", "PyLong_AsLongLong", "PyLong_AsSsize_t",
+      "PyLong_AsUnsignedLong", "PyLong_AsSize_t",
+      "PyFloat_AsDouble", "PyFloat_AS_DOUBLE",
+      "PyComplex_RealAsDouble", "PyComplex_ImagAsDouble"
+    ],
+    "raw_memory": [
+      "PyMem_Malloc", "PyMem_Calloc", "PyMem_Realloc", "PyMem_Free",
+      "PyMem_RawMalloc", "PyMem_RawCalloc", "PyMem_RawRealloc", "PyMem_RawFree"
+    ],
+    "gc_traversal": [
+      "Py_VISIT"
+    ],
+    "atomic_operations": [
+      "_Py_atomic_load_int", "_Py_atomic_store_int",
+      "_Py_atomic_load_int_relaxed", "_Py_atomic_store_int_relaxed",
+      "_Py_atomic_add_int",
+      "_Py_atomic_load_ssize", "_Py_atomic_store_ssize",
+      "_Py_atomic_load_ssize_relaxed", "_Py_atomic_store_ssize_relaxed",
+      "_Py_atomic_load_ptr", "_Py_atomic_store_ptr",
+      "_Py_atomic_load_ptr_relaxed", "_Py_atomic_store_ptr_relaxed",
+      "_Py_atomic_compare_exchange_ptr",
+      "_Py_TryIncref", "_Py_TryIncrefCompare"
+    ],
+    "stw_control": [
+      "_PyEval_StartTheWorld", "_PyEval_StartTheWorldAll"
+    ],
+    "misc_safe": [
+      "PyType_HasFeature",
+      "PyObject_IS_GC",
+      "_PyObject_GC_IS_TRACKED",
+      "PyGC_Head"
+    ]
+  },
+
+  "unsafe_during_stw": {
+    "_comment": "These operations may invoke Python code, trigger GC, set exceptions, or acquire contested locks. Call _PyEval_StartTheWorld BEFORE using these.",
+    "invokes_python_code": [
+      "PyObject_Call", "PyObject_CallObject", "PyObject_CallFunction",
+      "PyObject_CallMethod", "PyObject_CallNoArgs", "PyObject_CallOneArg",
+      "PyObject_Vectorcall",
+      "PyObject_GetAttr", "PyObject_GetAttrString",
+      "PyObject_SetAttr", "PyObject_SetAttrString",
+      "PyObject_GetItem", "PyObject_SetItem", "PyObject_DelItem",
+      "PyObject_Str", "PyObject_Repr", "PyObject_ASCII",
+      "PyObject_Bytes", "PyObject_Format",
+      "PyObject_RichCompare", "PyObject_RichCompareBool",
+      "PyObject_Hash", "PyObject_IsTrue",
+      "PyObject_GenericGetAttr", "PyObject_GenericSetAttr",
+      "PyObject_GetOptionalAttr",
+      "PyIter_Next",
+      "PyNumber_Add", "PyNumber_Subtract", "PyNumber_Multiply",
+      "PyNumber_TrueDivide", "PyNumber_FloorDivide",
+      "PyNumber_Remainder", "PyNumber_Power",
+      "PyNumber_Negative", "PyNumber_Positive", "PyNumber_Absolute",
+      "PyNumber_Long", "PyNumber_Float", "PyNumber_Index",
+      "PySequence_GetItem", "PySequence_SetItem", "PySequence_Length",
+      "PySequence_Contains", "PySequence_Concat",
+      "PyMapping_GetItemString",
+      "PyImport_ImportModule", "PyImport_Import"
+    ],
+    "allocation_note": "REVISION (2026-04-04): On Python 3.14+ free-threading builds, object allocation does NOT trigger GC synchronously. GC runs only on the eval breaker in the bytecode loop (since 3.12, commit 83eb827247dd), and _PyObject_GC_TRACK does not call _Py_TriggerGC on Py_GIL_DISABLED builds. Analysis by YiFei Zhu (guppy3 maintainer) tracing PyType_GenericAlloc paths through 3.10→3.15. The APIs below are SAFE for allocation purposes on 3.14+, but remain unsafe if they invoke Python code (e.g., __init__, __hash__). See safe_allocation_on_314 below.",
+
+    "safe_allocation_on_314": {
+      "_comment": "These APIs allocate but do NOT trigger GC on 3.14+ free-threading builds. Safe during STW for allocation purposes. Still unsafe if they invoke Python callbacks (__init__, __del__, __hash__, __eq__).",
+      "safe_if_builtin_types_only": [
+        "PyObject_GC_New", "PyObject_GC_NewVar",
+        "PyObject_New", "PyObject_NewVar",
+        "PyObject_Malloc", "PyObject_Realloc",
+        "PyList_New", "PyTuple_New", "PyTuple_Pack",
+        "PyDict_New", "PyDict_Copy",
+        "PySet_New", "PyFrozenSet_New",
+        "PyUnicode_FromString", "PyUnicode_FromFormat",
+        "PyBytes_FromString", "PyBytes_FromStringAndSize",
+        "PyLong_FromLong", "PyLong_FromSsize_t", "PyLong_FromDouble",
+        "PyFloat_FromDouble",
+        "Py_BuildValue",
+        "PyStructSequence_New"
+      ]
+    },
+
+    "may_trigger_gc_or_alloc_pre314": [
+      "PyObject_GC_New", "PyObject_GC_NewVar",
+      "PyObject_GC_Track", "PyObject_GC_UnTrack",
+      "PyObject_New", "PyObject_NewVar",
+      "PyObject_Malloc", "PyObject_Realloc", "PyObject_Free",
+      "PyList_New", "PyTuple_New", "PyTuple_Pack",
+      "PyDict_New", "PyDict_Copy",
+      "PySet_New", "PyFrozenSet_New",
+      "PyUnicode_FromString", "PyUnicode_FromFormat",
+      "PyBytes_FromString", "PyBytes_FromStringAndSize",
+      "PyLong_FromLong", "PyLong_FromSsize_t", "PyLong_FromDouble",
+      "PyFloat_FromDouble",
+      "Py_BuildValue",
+      "PyStructSequence_New"
+    ],
+    "exception_setting": {
+      "_comment": "REVISION (2026-04-04): PyErr_NoMemory is conditionally safe during STW on 3.14+. It only reads a thread-local, gets a singleton, and calls Py_XDECREF(tstate->current_exception). The Py_XDECREF is safe IF no exception is currently set (the common case during STW traversal). If a previous exception IS set and its type has a __del__, the decref could invoke Python code. Rule: ensure no exception is set before calling PyErr_NoMemory during STW. Other PyErr_* functions that use format strings with %R/%S invoke PyObject_Repr/Str — unsafe.",
+      "always_unsafe_during_stw": [
+        "PyErr_Format",
+        "PyErr_SetFromErrno",
+        "PyErr_CheckSignals",
+        "PyErr_NewException",
+        "PyErr_SetFromWindowsErr"
+      ],
+      "conditionally_safe_during_stw": {
+        "PyErr_NoMemory": "Safe IF no exception is currently set. Py_XDECREF(tstate->current_exception) could invoke __del__ on custom exception types.",
+        "PyErr_SetString": "Safe IF the exception type is a built-in type (no custom __init__) and no previous exception is set.",
+        "PyErr_SetObject": "Safe IF both exception type and value are built-in types and no previous exception is set.",
+        "PyErr_Occurred": "Safe — only reads tstate->current_exception (thread-local).",
+        "PyErr_Clear": "Conditionally safe — calls Py_XDECREF on current exception. Same __del__ risk as PyErr_NoMemory."
+      },
+      "unsafe_during_stw": [
+        "PyErr_Fetch", "PyErr_Restore",
+        "PyErr_GetRaisedException", "PyErr_SetRaisedException"
+      ]
+    },
+    "container_mutation": [
+      "PyList_Append", "PyList_Insert", "PyList_SetSlice",
+      "PyList_Sort", "PyList_Reverse",
+      "PyDict_SetItem", "PyDict_SetItemString",
+      "PyDict_DelItem", "PyDict_DelItemString",
+      "PyDict_Clear", "PyDict_Update", "PyDict_Merge",
+      "PyDict_GetItem", "PyDict_GetItemString",
+      "PyDict_GetItemWithError", "PyDict_GetItemRef",
+      "PyDict_Contains",
+      "PySet_Add", "PySet_Discard", "PySet_Pop"
+    ],
+    "module_and_type": [
+      "PyModule_Create", "PyModule_AddObject", "PyModule_AddObjectRef",
+      "PyModuleDef_Init",
+      "PyType_Ready", "PyType_FromSpec",
+      "PyType_FromModuleAndSpec",
+      "PySys_GetObject", "PySys_SetObject"
+    ],
+    "stw_start": [
+      "_PyEval_StopTheWorld", "_PyEval_StopTheWorldAll"
+    ]
+  },
+
+  "stw_contract": {
+    "summary": "During _PyEval_StopTheWorld, all other threads are suspended at safe points. The calling thread has exclusive access to all Python objects. Operations that invoke Python code (__getattr__, __hash__, __eq__, __str__, __del__) are always unsafe. On Python 3.14+ free-threading builds, object ALLOCATION is safe (GC only runs on the eval breaker, not during allocation). Exception setting is conditionally safe (see details).",
+    "rules": [
+      "Do NOT call any Python/C API that could invoke Python code (__getattr__, __hash__, __eq__, __str__, etc.)",
+      "Do NOT call _PyEval_StopTheWorld again (nested STW deadlocks)",
+      "On 3.14+: Object allocation (PyList_New, PyDict_New, etc.) IS safe — GC runs only on eval breaker, not during allocation",
+      "On <3.14: Object allocation may trigger GC — avoid during STW",
+      "PyErr_NoMemory IS safe during STW IF no exception is currently set (Py_XDECREF on current_exception could invoke __del__)",
+      "PyErr_SetString/SetObject IS safe during STW IF exception type is built-in AND no previous exception is set",
+      "PyErr_Format with %R/%S is NEVER safe during STW (invokes PyObject_Repr/Str)",
+      "Dict operations with CheckExact types (PyDict_SetItem on builtin keys/values) are safe — no __hash__/__eq__ callbacks",
+      "DO use direct struct access (Py_TYPE, PyTuple_GET_ITEM, etc.) for reading object state",
+      "DO use Py_INCREF/Py_DECREF for reference counting",
+      "DO use PyMem_Malloc/PyMem_Free for raw C memory allocation",
+      "DO use _Py_atomic_* for atomic operations",
+      "DO call _PyEval_StartTheWorld before returning to Python or invoking non-builtin Python code"
+    ],
+    "cpython_evidence": {
+      "gc_free_threading.c:2223": "_PyEval_StartTheWorld called BEFORE PyErr_NoMemory — historically cautious, but analysis shows PyErr_NoMemory is safe IF no exception set (see revision note)",
+      "gc_free_threading.c:2253": "_PyEval_StartTheWorld called BEFORE cleanup_worklist/call_weakref_callbacks — Python code unsafe during STW",
+      "gcmodule.c:287-289": "append_referrents runs during STW (reads only), result processing after StartTheWorld",
+      "commit 83eb827247dd (3.12)": "GC now runs only on eval breaker — object allocation no longer triggers GC synchronously",
+      "commit 0c01090ad957 (3.15/3.14.1)": "Removed last remaining gc_collect_generations call from _PyObject_GC_Link",
+      "_PyObject_GC_TRACK": "On Py_GIL_DISABLED builds, does NOT call _Py_TriggerGC — confirmed by YiFei Zhu tracing 3.14 source"
+    },
+    "revision_history": [
+      "2026-04-02: Initial contract — conservative, based on CPython GC's own StartTheWorld-before-PyErr_NoMemory pattern",
+      "2026-04-04: Revised based on YiFei Zhu's analysis — allocation safe on 3.14+ (GC eval-breaker-only), PyErr_NoMemory conditionally safe, dict ops safe with CheckExact types"
+    ]
+  }
+}

--- a/plugins/cpython-review-toolkit/scripts/check_known_issues.py
+++ b/plugins/cpython-review-toolkit/scripts/check_known_issues.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import scan_ft_races
 import scan_null_checks
 import scan_pyerr_clear
 import scan_recursion_guards
@@ -48,7 +49,7 @@ from scan_common import build_report, parse_common_args, resolve_roots
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 _DEFAULT_CATALOG = _DATA_DIR / "cpython_known_bugs.tsv"
 
-# Category -> scanner module. ``None`` means "no scanner exists in v0.5"; such
+# Category -> scanner module. ``None`` means "no scanner exists yet"; such
 # entries are carried through as ``no_scanner`` so the catalog stays complete.
 CATEGORY_SCANNERS: dict[str, object] = {
     "recursion": scan_recursion_guards,
@@ -56,7 +57,7 @@ CATEGORY_SCANNERS: dict[str, object] = {
     "uninit-dealloc": scan_uninit_dealloc,
     "null-deref": scan_null_checks,
     "refcount": scan_refcounts,
-    "tsan": None,
+    "tsan": scan_ft_races,
     "init-bypass": None,
 }
 
@@ -70,9 +71,11 @@ _ABSENCE_CAVEAT = (
     "`absent`. Always read the file before concluding a bug is fixed."
 )
 _NO_SCANNER_CAVEAT = (
-    "Categories `tsan` and `init-bypass` have no scanner in v0.5; their entries "
-    "are carried through as `no_scanner` (informational) so the catalog stays "
-    "complete, but they are not cross-referenced against a fresh scan."
+    "Category `init-bypass` has no scanner yet; its entries are carried through "
+    "as `no_scanner` (informational) so the catalog stays complete, but they are "
+    "not cross-referenced against a fresh scan. (`tsan` is now scanned by "
+    "scan_ft_races, but note the caveat above: a data race carries no scannable "
+    "token at many sites, so `absent` there still is not proof of a fix.)"
 )
 
 

--- a/plugins/cpython-review-toolkit/scripts/parse_tsan_report.py
+++ b/plugins/cpython-review-toolkit/scripts/parse_tsan_report.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Parse ThreadSanitizer (TSan) reports over CPython's own source into findings.
+
+Parses TSan text output, groups races by their source-location pair,
+deduplicates, and separates **CPython-source races** (the target — report them)
+from **framework / scaffolding noise** (filter them out).
+
+Key inversion vs. ft-review-toolkit's analyzer
+-----------------------------------------------
+The ft toolkit reviews *extensions*, so its analyzer treats a race whose frames
+live in CPython internals (``Objects/`` / ``Python/`` / ``Modules/``) as
+not-the-extension's-problem and filters it out. For cpython-review-toolkit the
+target **is** CPython, so that logic **inverts**: a race in CPython's own
+runtime source *is* the finding. Only pure thread-scaffolding / test-harness
+frames (thread bootstrap, ``pthread_create``, the ``_testcapi`` family) and
+genuinely third-party library frames (libc, libssl, the sanitizer runtime) are
+noise.
+
+Confirmed races get recorded in the local findings repo ``cpython-tsan-findings``;
+a race's signature there is the *unordered pair* of racing ``file:func`` sites,
+which is exactly the ``signature`` field each finding carries here.
+
+Unlike the tree-sitter scanners in this toolkit, this uses regex (not
+Tree-sitter) because TSan output is plain text, not C source — so it needs
+neither the tree-sitter chassis nor CPython-root detection. Stdlib only.
+
+Usage:
+    python parse_tsan_report.py /path/to/tsan_report.txt
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Patterns for parsing TSan output.
+_WARNING_RE = re.compile(r"WARNING: ThreadSanitizer: (.+?)(?:\s+\(pid=\d+\))?\s*$")
+_ACCESS_RE = re.compile(
+    r"^\s+((?:Previous )?(?:[Ww]rite|[Rr]ead)) of size (\d+) "
+    r"at (0x[0-9a-f]+) by (.*?):\s*$"
+)
+_FRAME_RE = re.compile(r"^\s+#(\d+)\s+(\S+)\s+(.+?)(?:\s+\((.+?)\))?\s*$")
+_LOCATION_RE = re.compile(
+    # Not end-anchored: heap-location lines carry a trailing
+    # "allocated by thread T1:" that global-location lines do not.
+    r"^\s+Location is (.+?) of size (\d+) at (0x[0-9a-f]+)(?:\s+\((.+?)\))?"
+)
+_THREAD_CREATE_RE = re.compile(
+    r"^\s+Thread T(\d+)\s+'?(.*?)'?\s+(?:\(tid=\d+.*?\)\s+)?created by (.*?) at:\s*$"
+)
+_SUMMARY_RE = re.compile(
+    r"^SUMMARY: ThreadSanitizer: (.+?)\s+(\S+?)(?::(\d+))?(?::(\d+))?"
+    r"\s+in\s+(.+?)\s*$"
+)
+_SEPARATOR_RE = re.compile(r"^={10,}$")
+
+# Frames that are pure scaffolding / test-harness / third-party — NOT the
+# target. Checked *before* the CPython-source patterns so that, e.g., the thread
+# bootstrap living in Modules/_threadmodule.c is classified as noise rather than
+# as a CPython-source race.
+_NOISE_PATTERNS = [
+    # CPython's built-in test-harness modules (present in the tree, not target).
+    r"_testcapi",
+    r"_testinternalcapi",
+    r"_testlimitedcapi",
+    r"_testbuffer",
+    r"_testmultiphase",
+    r"_testsinglephase",
+    r"_testimportmultiple",
+    r"_testclinic",
+    r"_testexternalinspection",
+    r"_xxtestfuzz",
+    r"_ctypes_test",
+    # Python-level test tree.
+    r"/Lib/test/",
+    # Thread scaffolding / interpreter bootstrap plumbing.
+    r"\bt_bootstrap\b",
+    r"\bthread_run\b",
+    r"\bpythread_wrapper\b",
+    r"\bbootstrap_thread\b",
+    r"\bstart_new_thread\b",
+    r"\bdo_start_new_thread\b",
+    r"\bstart_thread\b",
+    r"\bpthread_\w+",
+    # Sanitizer runtime.
+    r"__tsan",
+    r"__sanitizer",
+    r"libtsan",
+    r"libclang_rt",
+    # System / third-party libraries.
+    r"libc\.so",
+    r"libpthread",
+    r"libm\.so",
+    r"ld-linux",
+    r"/usr/lib/",
+    r"/usr/include/",
+]
+_NOISE_RE = re.compile("|".join(_NOISE_PATTERNS))
+
+# Frames that live in CPython's own runtime source — the target.
+_CPYTHON_SOURCE_PATTERNS = [
+    r"/Objects/",
+    r"/Python/",
+    r"/Modules/",
+    r"/Include/",
+    r"/Parser/",
+    r"pycore_",
+    r"pyconfig",
+]
+_CPYTHON_SOURCE_RE = re.compile("|".join(_CPYTHON_SOURCE_PATTERNS))
+
+
+def _parse_stack_frame(line: str) -> dict | None:
+    """Parse a single stack-frame line.
+
+    Returns dict with: frame_num, function, location, module, file, line, col.
+    """
+    m = _FRAME_RE.match(line)
+    if not m:
+        return None
+
+    frame_num = int(m.group(1))
+    function = m.group(2)
+    location = m.group(3).strip()
+    module = m.group(4) or ""
+
+    # Parse file:line:col out of the location component.
+    file_path = None
+    line_num = None
+    col_num = None
+    loc_match = re.match(r"(.+?):(\d+):(\d+)", location)
+    if loc_match:
+        file_path = loc_match.group(1)
+        line_num = int(loc_match.group(2))
+        col_num = int(loc_match.group(3))
+    else:
+        loc_match = re.match(r"(.+?):(\d+)\s*$", location)
+        if loc_match:
+            file_path = loc_match.group(1)
+            line_num = int(loc_match.group(2))
+        elif location and location != "<null>":
+            file_path = location
+
+    return {
+        "frame_num": frame_num,
+        "function": function,
+        "location": location,
+        "module": module,
+        "file": file_path,
+        "line": line_num,
+        "col": col_num,
+    }
+
+
+def _classify_frame(frame: dict) -> str:
+    """Classify a frame as ``cpython`` (target), ``noise``, or ``unknown``.
+
+    Noise is checked first so thread-bootstrap / test-harness frames that
+    happen to live under ``Modules/`` are not mistaken for target code.
+    """
+    combined = " ".join(
+        str(frame.get(k, "") or "") for k in ("location", "module", "function")
+    )
+    if _NOISE_RE.search(combined):
+        return "noise"
+    if _CPYTHON_SOURCE_RE.search(combined):
+        return "cpython"
+    return "unknown"
+
+
+def _get_cpython_frame(frames: list[dict]) -> dict | None:
+    """Return the first CPython-source frame in a stack (skipping scaffolding)."""
+    for frame in frames:
+        if _classify_frame(frame) == "cpython":
+            return frame
+    return None
+
+
+def _frame_site(frame: dict) -> str:
+    """Render a ``file:func`` site string for a frame (basename for stability)."""
+    file_path = frame.get("file")
+    base = os.path.basename(file_path) if file_path else (frame.get("module") or "?")
+    func = frame.get("function") or "?"
+    return f"{base}:{func}"
+
+
+def _parse_tsan_block(lines: list[str]) -> dict | None:
+    """Parse a single TSan warning block into a structured finding."""
+    if not lines:
+        return None
+
+    race_type = None
+    for line in lines:
+        m = _WARNING_RE.match(line)
+        if m:
+            race_type = m.group(1)
+            break
+    if not race_type:
+        return None
+
+    accesses: list[dict] = []
+    current_access: dict | None = None
+    thread_info: list[dict] = []
+    location_info: dict | None = None
+
+    for line in lines:
+        # Access header (Write/Read of size N).
+        access_m = _ACCESS_RE.match(line)
+        if access_m:
+            if current_access:
+                accesses.append(current_access)
+            current_access = {
+                "access_type": access_m.group(1).strip(),
+                "size": int(access_m.group(2)),
+                "address": access_m.group(3),
+                "thread": access_m.group(4).strip(),
+                "frames": [],
+            }
+            continue
+
+        # Location info — ends the current access; its frames are not part of it.
+        loc_m = _LOCATION_RE.match(line)
+        if loc_m:
+            location_info = {
+                "description": loc_m.group(1),
+                "size": int(loc_m.group(2)),
+                "address": loc_m.group(3),
+                "module": loc_m.group(4) or "",
+            }
+            if current_access:
+                accesses.append(current_access)
+                current_access = None
+            continue
+
+        # Thread-creation info — also ends the current access.
+        thread_m = _THREAD_CREATE_RE.match(line)
+        if thread_m:
+            if current_access:
+                accesses.append(current_access)
+                current_access = None
+            thread_info.append(
+                {
+                    "thread_id": int(thread_m.group(1)),
+                    "thread_name": thread_m.group(2),
+                    "creator": thread_m.group(3),
+                }
+            )
+            continue
+
+        # Stack frame — only attach while we are inside an access.
+        frame = _parse_stack_frame(line)
+        if frame and current_access:
+            current_access["frames"].append(frame)
+            continue
+
+    if current_access:
+        accesses.append(current_access)
+
+    # Summary line.
+    summary = None
+    for line in lines:
+        sum_m = _SUMMARY_RE.match(line)
+        if sum_m:
+            summary = {
+                "type": sum_m.group(1),
+                "file": sum_m.group(2),
+                "line": int(sum_m.group(3)) if sum_m.group(3) else None,
+                "col": int(sum_m.group(4)) if sum_m.group(4) else None,
+                "function": sum_m.group(5),
+            }
+            break
+
+    if not accesses:
+        return None
+
+    # The racing sites: the first CPython-source frame of each access (or the
+    # top frame if none is CPython source).
+    sites: list[dict] = []
+    cpython_frames: list[dict] = []
+    for access in accesses:
+        cf = _get_cpython_frame(access["frames"])
+        if cf:
+            cpython_frames.append(cf)
+        chosen = cf or (access["frames"][0] if access["frames"] else None)
+        if chosen:
+            sites.append(
+                {
+                    "file": os.path.basename(chosen["file"])
+                    if chosen.get("file")
+                    else None,
+                    "func": chosen.get("function"),
+                    "line": chosen.get("line"),
+                    "site": _frame_site(chosen),
+                    "is_cpython": _classify_frame(chosen) == "cpython",
+                }
+            )
+
+    is_cpython_race = len(cpython_frames) > 0
+    is_noise = not is_cpython_race
+
+    return {
+        "race_type": race_type,
+        "accesses": accesses,
+        "location": location_info,
+        "thread_info": thread_info,
+        "summary": summary,
+        "is_cpython_race": is_cpython_race,
+        "is_noise": is_noise,
+        "sites": sites,
+        "cpython_frames": cpython_frames,
+    }
+
+
+def _split_tsan_blocks(text: str) -> list[list[str]]:
+    """Split TSan output into individual warning blocks by separator lines."""
+    blocks: list[list[str]] = []
+    current_block: list[str] = []
+    in_block = False
+
+    for line in text.splitlines():
+        if _SEPARATOR_RE.match(line):
+            if in_block and current_block:
+                blocks.append(current_block)
+                current_block = []
+                in_block = False
+            else:
+                in_block = True
+            continue
+        if in_block:
+            current_block.append(line)
+
+    if current_block:
+        blocks.append(current_block)
+
+    return blocks
+
+
+def _race_signature(finding: dict) -> str:
+    """Unordered pair of racing ``file:func`` sites — the findings-repo signature."""
+    parts = [s["site"] for s in finding.get("sites", []) if s.get("site")]
+    if not parts:
+        # Fall back to raw top frames so distinct races don't all collapse.
+        for access in finding.get("accesses", []):
+            if access["frames"]:
+                parts.append(_frame_site(access["frames"][0]))
+    parts.sort()
+    return " | ".join(parts)
+
+
+def _deduplicate_races(findings: list[dict]) -> list[dict]:
+    """Deduplicate findings by their racing-site-pair signature."""
+    seen: dict[str, int] = {}
+    deduped: list[dict] = []
+
+    for finding in findings:
+        key = _race_signature(finding)
+        finding["signature"] = key
+        if key in seen:
+            idx = seen[key]
+            deduped[idx]["frequency"] = deduped[idx].get("frequency", 1) + 1
+        else:
+            seen[key] = len(deduped)
+            finding["frequency"] = 1
+            deduped.append(finding)
+
+    return deduped
+
+
+def _classify_severity(finding: dict) -> tuple[str, str]:
+    """Classify a finding's classification and severity."""
+    race_type = finding.get("race_type", "")
+    location = finding.get("location", {}) or {}
+    loc_desc = location.get("description", "") or ""
+
+    # A race on a global / static variable is the most dangerous shape.
+    if "global" in loc_desc:
+        return "RACE", "CRITICAL"
+
+    access_types = [
+        a.get("access_type", "").lower() for a in finding.get("accesses", [])
+    ]
+    has_write = any("write" in t for t in access_types)
+
+    if has_write and len(access_types) >= 2:
+        return "RACE", "HIGH"
+    if "data race" in race_type.lower():
+        return "RACE", "HIGH"
+    return "RACE", "MEDIUM"
+
+
+def parse_report(text: str) -> dict:
+    """Parse raw TSan report text into the structured findings envelope.
+
+    Pure function of the report text — no filesystem access — so it can be
+    driven directly from an inline fixture.
+    """
+    blocks = _split_tsan_blocks(text)
+    raw_findings: list[dict] = []
+    for block in blocks:
+        finding = _parse_tsan_block(block)
+        if finding:
+            raw_findings.append(finding)
+
+    deduped = _deduplicate_races(raw_findings)
+
+    findings: list[dict] = []
+    for finding in deduped:
+        classification, severity = _classify_severity(finding)
+        finding["classification"] = classification
+        finding["severity"] = severity
+        findings.append(finding)
+
+    cpython_races = [f for f in findings if f["is_cpython_race"]]
+    noise_races = [f for f in findings if f["is_noise"]]
+
+    return {
+        "total_warnings": len(raw_findings),
+        "unique_races": len(deduped),
+        "cpython_races": len(cpython_races),
+        "noise_races": len(noise_races),
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_classification": {
+                "RACE": len([f for f in findings if f["classification"] == "RACE"]),
+            },
+            "by_severity": {
+                s: len([f for f in findings if f["severity"] == s])
+                for s in ("CRITICAL", "HIGH", "MEDIUM", "LOW")
+                if any(f["severity"] == s for f in findings)
+            },
+            "actionable": len(cpython_races),
+            "noise": len(noise_races),
+        },
+        "findings_repo": "cpython-tsan-findings",
+    }
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Parse a TSan report *file* into the structured findings envelope.
+
+    Args:
+        target: Path to the TSan report text file.
+        max_files: Unused — kept for calling-convention compatibility.
+    """
+    report_path = Path(target).resolve()
+
+    if not report_path.exists():
+        return {
+            "error": f"TSan report not found: {report_path}",
+            "report_path": str(report_path),
+        }
+
+    try:
+        text = report_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return {
+            "error": f"Failed to read report: {e}",
+            "report_path": str(report_path),
+        }
+
+    report = parse_report(text)
+    report = {"report_path": str(report_path), **report}
+    return report
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        json.dump(
+            {"error": "Usage: parse_tsan_report.py <tsan_report_file>"}, sys.stdout
+        )
+        sys.stdout.write("\n")
+        sys.exit(2)
+
+    target = sys.argv[1]
+    try:
+        result = analyze(target)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        if "error" in result:
+            sys.exit(1)
+    except Exception as e:  # noqa: BLE001
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_ft_races.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_ft_races.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for free-threading data races in its own code.
+
+Targets the three most mechanically-detectable race classes from the fusil
+`cpython-tsan-findings` catalog. CPython's free-threaded build (``Py_GIL_DISABLED``)
+makes these real, reachable-from-Python crashes, not hypotheticals.
+
+* **T3 — iterator-exhaustion double-DECREF** (the fixed-template, ~zero-FP one):
+  a ``*_iternext`` slot drops an owning reference to a shared self-member
+  (``Py_CLEAR(it->it_seq)`` / ``it->it_seq = NULL; Py_DECREF(seq);``) with no
+  critical section. Two ``next()`` threads read the same borrowed sequence and
+  both DECREF it → double-free. Confirmed: dict iter (gh-154130), set iter
+  (gh-144357), StringIO iter (gh-153296).
+
+* **T2 — lazy-init cache without a critical section**: ``if (!self->f) self->f =
+  compute();`` with no critical section in the function — two threads both see
+  NULL, both compute and store (leak + torn/lost write). Confirmed:
+  ``descr_get_qualname`` (Objects/descrobject.c, TSAN-0043).
+
+* **T1 — atomic/plain access asymmetry**: a struct field accessed via an atomic
+  macro (``_Py_atomic_*`` / ``FT_ATOMIC_*``) at one site and as a plain
+  ``x->field`` load/store at another in the same file. The asymmetry means one
+  access is unsynchronized. Confirmed: itertools ``count_repr`` (TSAN-0006).
+
+Usage:
+    python scan_ft_races.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    parse_bytes,
+)
+
+# A function has "some locking" if any of these appear — covers
+# Py_BEGIN_CRITICAL_SECTION / _SECTION2 / _SECTION_MUTEX (all share the prefix).
+_LOCK_TOKENS = ("Py_BEGIN_CRITICAL_SECTION", "PyMutex_Lock", "_PyCriticalSection")
+
+# Atomic access macros (CPython's own FT wrappers + the low-level primitives).
+_ATOMIC_ACCESS_RE = re.compile(
+    r"(?:_Py_atomic_\w+|FT_ATOMIC_\w+)\s*\(\s*&?\s*\w+\s*->\s*(\w+)"
+)
+_PLAIN_MEMBER_RE = re.compile(r"\b(\w+)\s*->\s*(\w+)\b")
+
+# iternext slot wiring (designated init + PyType_Slot spec form).
+_ITERNEXT_DESIGNATED_RE = re.compile(
+    r"\.tp_iternext\s*=\s*(?:\(\s*\w[\w\s\*]*\)\s*)?(?:&\s*)?(\w+)"
+)
+_ITERNEXT_SPEC_RE = re.compile(r"\{\s*Py_tp_iternext\s*,\s*(?:&\s*)?(\w+)\s*\}")
+
+# T3: dropping an owning ref to a self-member.
+_MEMBER_CLEAR_RE = re.compile(r"Py_CLEAR\s*\(\s*\w+\s*->\s*\w+\s*\)")
+_MEMBER_SET_NULL_RE = re.compile(r"\b\w+\s*->\s*\w+\s*=\s*NULL\b")
+_DECREF_RE = re.compile(r"\bPy_X?DECREF\s*\(")
+
+# T2: lazy-init of a self-member guarded only by a NULL check.
+_LAZY_INIT_RE = re.compile(
+    r"if\s*\(\s*(?:!\s*)?(\w+)\s*->\s*(\w+)\s*(?:==\s*NULL\s*)?\)\s*"
+    r"(?:\{)?[^;{}]*?\1\s*->\s*\2\s*=\s*(?!=)",
+    re.DOTALL,
+)
+
+
+def _has_lock(body: str) -> bool:
+    return any(tok in body for tok in _LOCK_TOKENS)
+
+
+def _caller_holds_lock(func_name: str) -> bool:
+    """CPython FT convention: a ``*_lock_held`` function runs with the critical
+    section already held by its caller, so the lock is not missing here."""
+    return func_name.endswith(("_lock_held", "_locked"))
+
+
+def _collect_iternext_names(source: str) -> set[str]:
+    names = set(_ITERNEXT_DESIGNATED_RE.findall(source))
+    names |= set(_ITERNEXT_SPEC_RE.findall(source))
+    return names
+
+
+def _is_iternext(func_name: str, slot_names: set[str]) -> bool:
+    return func_name in slot_names or "iternext" in func_name
+
+
+def _line_of(body: str, match_start: int, func_start_line: int) -> int:
+    return func_start_line + body[:match_start].count("\n")
+
+
+def _check_t3(func: dict, is_iter: bool, tree, source_bytes: bytes) -> dict | None:
+    """T3: iternext that drops an owning self-member ref without a lock."""
+    if not is_iter or _caller_holds_lock(func["name"]):
+        return None
+    body = func["body"]
+    if _has_lock(body):
+        return None
+
+    clear_m = _MEMBER_CLEAR_RE.search(body)
+    drop_start: int | None = None
+    if clear_m:
+        drop_start = clear_m.start()
+    else:
+        setnull_m = _MEMBER_SET_NULL_RE.search(body)
+        if setnull_m is not None and _DECREF_RE.search(body):
+            drop_start = setnull_m.start()
+    if drop_start is None:
+        return None
+
+    line = _line_of(body, drop_start, func["start_line"])
+    if is_suppressed_by_comment(source_bytes, tree, line):
+        return None
+    return {
+        "type": "iternext_double_decref",
+        "ft_class": "T3",
+        "function": func["name"],
+        "line": line,
+        "confidence": "high",
+        "detail": (
+            f"'{func['name']}' is a tp_iternext that drops an owning reference "
+            "to a shared self-member (Py_CLEAR / member=NULL + Py_DECREF) with "
+            "no Py_BEGIN_CRITICAL_SECTION. Under the free-threaded build two "
+            "concurrent next() calls read the same borrowed sequence and both "
+            "DECREF it -> double-free (cf. gh-154130 dict, gh-144357 set, "
+            "gh-153296 StringIO). Wrap the iternext body in "
+            "Py_BEGIN_CRITICAL_SECTION(self)."
+        ),
+    }
+
+
+def _check_t2(func: dict, tree, source_bytes: bytes) -> list[dict]:
+    """T2: lazy-init of a self-member guarded only by a NULL check."""
+    if _caller_holds_lock(func["name"]):
+        return []
+    body = func["body"]
+    if _has_lock(body):
+        return []
+    findings: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for m in _LAZY_INIT_RE.finditer(body):
+        obj, field = m.group(1), m.group(2)
+        if (obj, field) in seen:
+            continue
+        seen.add((obj, field))
+        line = _line_of(body, m.start(), func["start_line"])
+        if is_suppressed_by_comment(source_bytes, tree, line):
+            continue
+        findings.append(
+            {
+                "type": "lazy_init_no_critical_section",
+                "ft_class": "T2",
+                "function": func["name"],
+                "member": f"{obj}->{field}",
+                "line": line,
+                "confidence": "medium",
+                "detail": (
+                    f"Lazy init of '{obj}->{field}' guarded only by a NULL "
+                    "check, with no critical section. Under free-threading two "
+                    "threads both observe NULL and both compute/store -> leak + "
+                    "torn/lost write (cf. gh descr_get_qualname / TSAN-0043). "
+                    "Guard with Py_BEGIN_CRITICAL_SECTION or a compare-exchange."
+                ),
+            }
+        )
+    return findings
+
+
+def _check_t1(source: str, rel: str) -> list[dict]:
+    """T1: a field accessed atomically at one site and plainly at another."""
+    atomic_fields = set(_ATOMIC_ACCESS_RE.findall(source))
+    if not atomic_fields:
+        return []
+
+    # Byte ranges covered by atomic-macro calls, so plain accesses inside an
+    # atomic call are not counted as "plain".
+    atomic_spans = [(m.start(), m.end()) for m in _ATOMIC_ACCESS_RE.finditer(source)]
+
+    def _in_atomic(pos: int) -> bool:
+        return any(s <= pos < e for s, e in atomic_spans)
+
+    findings: list[dict] = []
+    reported: set[str] = set()
+    for m in _PLAIN_MEMBER_RE.finditer(source):
+        field = m.group(2)
+        if field not in atomic_fields or field in reported:
+            continue
+        if _in_atomic(m.start()):
+            continue
+        reported.add(field)
+        line = source[: m.start()].count("\n") + 1
+        findings.append(
+            {
+                "type": "atomic_plain_asymmetry",
+                "ft_class": "T1",
+                "file": rel,
+                "member": field,
+                "line": line,
+                "confidence": "low",
+                "detail": (
+                    f"Field '{field}' is accessed via an atomic macro "
+                    "(_Py_atomic_* / FT_ATOMIC_*) elsewhere in this file but is "
+                    f"read/written plainly here — one access is unsynchronized "
+                    "(cf. itertools count_repr / TSAN-0006). Make every access "
+                    "to a concurrently-shared field atomic, or hold a lock."
+                ),
+            }
+        )
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for free-threading data races (T1/T2/T3) in CPython's own code."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    total_functions = 0
+    iternext_functions = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        source = source_bytes.decode("utf-8", errors="replace")
+        # T1 is file-scoped (needs cross-function field access map).
+        for f in _check_t1(source, relpath(filepath, project_root)):
+            findings.append(f)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        rel = relpath(filepath, project_root)
+        slot_names = _collect_iternext_names(source)
+
+        for func in functions:
+            total_functions += 1
+            is_iter = _is_iternext(func["name"], slot_names)
+            if is_iter:
+                iternext_functions += 1
+            t3 = _check_t3(func, is_iter, tree, source_bytes)
+            if t3 is not None:
+                t3["file"] = rel
+                findings.append(t3)
+            for f in _check_t2(func, tree, source_bytes):
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_class: dict[str, int] = defaultdict(int)
+    by_confidence: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_class[f["ft_class"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_class": dict(by_class),
+            "by_confidence": dict(by_confidence),
+        },
+        iternext_functions=iternext_functions,
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_lock_discipline.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_lock_discipline.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for critical-section / lock-discipline issues.
+
+CPython's own ``Objects/``, ``Modules/`` and ``Python/`` use per-object
+critical sections pervasively for free-threading (PEP 703): dozens of
+``Py_BEGIN_CRITICAL_SECTION(op)`` / ``Py_END_CRITICAL_SECTION()`` pairs live in
+``Objects/dictobject.c`` alone. The macros are *scoped*: ``BEGIN`` opens a
+brace and declares a stack-local ``PyCriticalSection`` that ``END`` pops. Leave
+the section on any path without the matching ``END`` and the per-object lock is
+never released — a deadlock the moment two threads contend the object.
+
+This scanner focuses on the two highest-signal shapes on CPython's own code:
+
+* ``critical_section_missing_end`` / ``critical_section_end_on_error`` (FIX) —
+  a ``Py_BEGIN_CRITICAL_SECTION`` (or the ``2`` / ``_MUTEX`` spelling) with no
+  matching ``Py_END`` on some path, typically an early ``return`` or an
+  out-of-section ``goto`` sitting between the begin and its end.
+* ``nested_critical_sections`` (CONSIDER) — two *different* objects locked at
+  once via two single-object begins instead of the deadlock-safe
+  ``Py_BEGIN_CRITICAL_SECTION2(a, b)``.
+
+The common, correct idiom (begin ... work ... end on every path) is silent.
+Analysis is intra-function only: a section opened in one function and closed in
+another is out of scope and honestly not modelled.
+
+Usage:
+    python scan_lock_discipline.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    find_calls_in_scope,
+    find_return_statements,
+    get_node_text,
+    parse_bytes,
+    walk_descendants,
+)
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+# The single-object begin/end spellings. The ``_2`` variant locks two objects
+# together (canonical order, deadlock-safe); the ``_MUTEX`` variant is
+# CPython's mutex-backed begin, ``Py_BEGIN_CRITICAL_SECTION_MUTEX(&m)``, paired
+# with the ordinary ``Py_END_CRITICAL_SECTION()``. ``_MUTEX`` is absent from the
+# verbatim sibling ``lock_macros.json`` (that file stays byte-for-byte in sync
+# with ft-review-toolkit), so it is spliced in here at the code level.
+_CS_BEGIN_1 = "Py_BEGIN_CRITICAL_SECTION"
+_CS_BEGIN_2 = "Py_BEGIN_CRITICAL_SECTION2"
+_CS_MUTEX_BEGIN = "Py_BEGIN_CRITICAL_SECTION_MUTEX"
+_CS_END_1 = "Py_END_CRITICAL_SECTION"
+_CS_END_2 = "Py_END_CRITICAL_SECTION2"
+
+_lock_data: dict | None = None
+
+
+def _load_lock_macros() -> dict:
+    """Load the (verbatim-vendored) lock-macro vocabulary from data/."""
+    global _lock_data
+    if _lock_data is not None:
+        return _lock_data
+    try:
+        with open(_DATA_DIR / "lock_macros.json", encoding="utf-8") as f:
+            _lock_data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:  # pragma: no cover - defensive
+        print(f"Warning: failed to load lock_macros.json: {e}", file=sys.stderr)
+        _lock_data = {}
+    return _lock_data
+
+
+def _get_critical_section_pair() -> tuple[set[str], set[str]]:
+    """Return ``(begin_macros, end_macros)`` for the critical-section family.
+
+    Sourced from the ``type == "critical_section"`` entry of the verbatim
+    ``lock_macros.json`` plus the CPython-only ``_MUTEX`` begin spelling.
+    """
+    begins: set[str] = set()
+    ends: set[str] = set()
+    for pair in _load_lock_macros().get("lock_pairs", []):
+        if pair.get("type") == "critical_section":
+            begins.update(pair.get("acquire", []))
+            ends.update(pair.get("release", []))
+    # Tolerate the mutex-backed begin CPython also uses.
+    begins.add(_CS_MUTEX_BEGIN)
+    return begins, ends
+
+
+def _matching_end(begin_name: str) -> str:
+    """Name of the ``END`` macro that closes a given ``BEGIN`` spelling."""
+    if begin_name == _CS_BEGIN_2:
+        return _CS_END_2
+    return _CS_END_1
+
+
+def _norm_args(args: str) -> str:
+    """Whitespace-insensitive normalization of a macro's argument text."""
+    return re.sub(r"\s+", "", args)
+
+
+# ---------------------------------------------------------------------------
+# Per-function analysis
+# ---------------------------------------------------------------------------
+
+
+def _collect_labels(func_node, source_bytes: bytes) -> dict[str, int]:
+    """Map ``label name -> start byte`` for every label in the function."""
+    labels: dict[str, int] = {}
+    for node in walk_descendants(func_node, "labeled_statement"):
+        label_node = node.child_by_field_name("label")
+        if label_node is not None:
+            labels[get_node_text(label_node, source_bytes)] = node.start_byte
+    return labels
+
+
+def _collect_exits(func_node, source_bytes: bytes) -> list[dict]:
+    """Collect every ``return`` and ``goto`` in the function (byte-ordered)."""
+    exits: list[dict] = []
+    for ret in find_return_statements(func_node, source_bytes):
+        exits.append(
+            {
+                "kind": "return",
+                "byte": ret["node"].start_byte,
+                "line": ret["start_line"],
+                "label": None,
+            }
+        )
+    for node in walk_descendants(func_node, "goto_statement"):
+        label_node = node.child_by_field_name("label")
+        exits.append(
+            {
+                "kind": "goto",
+                "byte": node.start_byte,
+                "line": node.start_point[0] + 1,
+                "label": get_node_text(label_node, source_bytes)
+                if label_node is not None
+                else None,
+            }
+        )
+    return exits
+
+
+def _analyze_critical_sections(func: dict, source_bytes: bytes) -> list[dict]:
+    """Flag missing / early-exited / nested critical sections in one function."""
+    begins_set, ends_set = _get_critical_section_pair()
+    calls = find_calls_in_scope(func["body_node"], source_bytes, begins_set | ends_set)
+    if not calls:
+        return []
+
+    events = sorted(
+        (
+            {
+                "name": c["function_name"],
+                "line": c["start_line"],
+                "byte": c["start_byte"],
+                "args": c["arguments_text"],
+                "is_begin": c["function_name"] in begins_set,
+                "end_byte": None,
+            }
+            for c in calls
+        ),
+        key=lambda e: e["byte"],
+    )
+
+    findings: list[dict] = []
+
+    # LIFO-pair begins with ends. While pairing, flag two different objects
+    # held at once (nested single-object begins) as a deadlock risk.
+    stack: list[dict] = []
+    for ev in events:
+        if ev["is_begin"]:
+            if stack:
+                outer = stack[-1]
+                if (
+                    ev["name"] != _CS_BEGIN_2
+                    and outer["name"] != _CS_BEGIN_2
+                    and _norm_args(ev["args"]) != _norm_args(outer["args"])
+                    and outer["args"]
+                    and ev["args"]
+                ):
+                    findings.append(_nested_finding(func, outer, ev))
+            stack.append(ev)
+        elif stack:
+            stack[-1]["end_byte"] = ev["byte"]
+            stack.pop()
+
+    # A begin left on the stack has no matching end on any path.
+    ended: list[dict] = []
+    for ev in events:
+        if not ev["is_begin"]:
+            continue
+        if ev["end_byte"] is None:
+            findings.append(_missing_end_finding(func, ev))
+        else:
+            ended.append(ev)
+
+    # A return/goto strictly between a begin and its matching end leaves the
+    # section open on that path. A goto whose target label is itself inside the
+    # section (e.g. a `retry:` loop) is an internal jump, not an exit.
+    labels = _collect_labels(func["body_node"], source_bytes)
+    exits = _collect_exits(func["body_node"], source_bytes)
+    for begin in ended:
+        e_byte = begin["end_byte"]
+        for exit_ in exits:
+            if not begin["byte"] < exit_["byte"] < e_byte:
+                continue
+            if exit_["kind"] == "goto":
+                target = labels.get(exit_["label"] or "")
+                if target is not None and begin["byte"] < target < e_byte:
+                    continue
+            findings.append(_end_on_error_finding(func, begin, exit_))
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Finding builders
+# ---------------------------------------------------------------------------
+
+
+def _missing_end_finding(func: dict, begin: dict) -> dict:
+    end = _matching_end(begin["name"])
+    return {
+        "type": "critical_section_missing_end",
+        "function": func["name"],
+        "line": begin["line"],
+        "classification": "FIX",
+        "confidence": "high",
+        "detail": (
+            f"{begin['name']}({begin['args']}) at line {begin['line']} in "
+            f"'{func['name']}' has no matching {end}() on any path — the per-object "
+            f"lock is never released, so the object stays locked (deadlock under "
+            f"free-threading). Add {end}() before the function returns."
+        ),
+    }
+
+
+def _end_on_error_finding(func: dict, begin: dict, exit_: dict) -> dict:
+    end = _matching_end(begin["name"])
+    where = (
+        f"return at line {exit_['line']}"
+        if exit_["kind"] == "return"
+        else f"goto {exit_['label']} at line {exit_['line']}"
+    )
+    return {
+        "type": "critical_section_end_on_error",
+        "function": func["name"],
+        "line": exit_["line"],
+        "classification": "FIX",
+        "confidence": "high",
+        "detail": (
+            f"{where} in '{func['name']}' leaves the critical section opened by "
+            f"{begin['name']}({begin['args']}) at line {begin['line']} without "
+            f"calling {end}() first — the per-object lock leaks on this path. Call "
+            f"{end}() before the exit (or restructure so the exit is inside the "
+            f"section's END)."
+        ),
+    }
+
+
+def _nested_finding(func: dict, outer: dict, inner: dict) -> dict:
+    return {
+        "type": "nested_critical_sections",
+        "function": func["name"],
+        "line": inner["line"],
+        "classification": "CONSIDER",
+        "confidence": "medium",
+        "detail": (
+            f"'{func['name']}' opens {inner['name']}({inner['args']}) at line "
+            f"{inner['line']} while the section from {outer['name']}({outer['args']}) "
+            f"at line {outer['line']} is still held — two different objects locked at "
+            f"once. If another thread locks them in the opposite order this "
+            f"deadlocks; use Py_BEGIN_CRITICAL_SECTION2({outer['args']}, "
+            f"{inner['args']}) to acquire both in a canonical order."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _has_critical_section(func: dict) -> bool:
+    """Cheap check: does the function mention any critical-section begin?"""
+    # ``Py_BEGIN_CRITICAL_SECTION`` is a prefix of the ``2`` and ``_MUTEX``
+    # spellings, so one substring test covers all three.
+    return _CS_BEGIN_1 in func["body"]
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for critical-section / lock-discipline issues in CPython C source."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    files_analyzed = 0
+    total_functions = 0
+    cs_functions = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        rel = relpath(filepath, project_root)
+
+        for func in functions:
+            total_functions += 1
+            if _has_critical_section(func):
+                cs_functions += 1
+            for f in _analyze_critical_sections(func, source_bytes):
+                if is_suppressed_by_comment(source_bytes, tree, f["line"]):
+                    continue
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_type: dict[str, int] = defaultdict(int)
+    by_classification: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_classification[f["classification"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_classification": dict(by_classification),
+        },
+        critical_section_functions=cs_functions,
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_stw_safety.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_stw_safety.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for StopTheWorld-safety violations in its own code.
+
+During ``_PyEval_StopTheWorld()`` (the free-threaded build's global pause) every
+*other* thread is suspended at a safe point. The stopping thread then has
+exclusive access to object graphs — but any operation that could invoke Python
+code, set an exception via the format machinery, or take a lock a stopped thread
+already holds is unsafe: it can deadlock the world or corrupt interpreter state.
+CPython encodes this contract in its own GC: ``Python/gc_free_threading.c:2223``
+calls ``_PyEval_StartTheWorld`` *before* ``PyErr_NoMemory``. This scanner audits
+CPython's own ``Python/`` / ``Objects/`` / ``Modules/`` code against that rule.
+
+Approach (mirrors the ft-review-toolkit reference this is ported from):
+
+1. Build an *intra-file* call graph with ``extract_functions`` +
+   ``find_calls_in_scope``.
+2. Propagate STW-safety through it: a function is unsafe if any transitive
+   callee (in the same file) is Python-invoking, keyed off
+   ``data/stw_safe_apis.json``.
+3. Find each ``_PyEval_StopTheWorld(...)..._PyEval_StartTheWorld(...)`` region and
+   flag every call inside it that resolves to unsafe (directly, or transitively
+   via a local helper) or that cannot be classified.
+
+Honest limitation: the call graph is intra-file only. A helper defined in
+another translation unit is treated as an unclassified (``unknown``) call, not
+followed. The agent triages those.
+
+Usage:
+    python scan_stw_safety.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    find_calls_in_scope,
+    get_node_text,
+    parse_bytes,
+)
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+_stw_data: dict | None = None
+
+# STW control functions are never violations themselves (the pairing/lock
+# discipline checker owns Stop/Start balance). They bracket the region.
+_STW_CONTROL = frozenset(
+    {
+        "_PyEval_StopTheWorld",
+        "_PyEval_StopTheWorldAll",
+        "_PyEval_StartTheWorld",
+        "_PyEval_StartTheWorldAll",
+    }
+)
+
+_STOP_RE = re.compile(r"_PyEval_StopTheWorld(?:All)?\s*\(")
+_START_RE = re.compile(r"_PyEval_StartTheWorld(?:All)?\s*\(")
+
+# Standard C library functions are STW-safe (no Python involvement).
+_C_STDLIB = frozenset(
+    {
+        "memcpy",
+        "memmove",
+        "memset",
+        "memcmp",
+        "strlen",
+        "strcmp",
+        "strncmp",
+        "strcpy",
+        "strncpy",
+        "printf",
+        "fprintf",
+        "sprintf",
+        "snprintf",
+        "malloc",
+        "calloc",
+        "realloc",
+        "free",
+        "assert",
+        "sizeof",
+        "offsetof",
+        "abs",
+        "labs",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Data-file loading + API classification
+# ---------------------------------------------------------------------------
+
+
+def _load_stw_apis() -> dict:
+    """Load STW safety classifications from ``data/stw_safe_apis.json``."""
+    global _stw_data
+    if _stw_data is not None:
+        return _stw_data
+    try:
+        with open(_DATA_DIR / "stw_safe_apis.json", encoding="utf-8") as f:
+            _stw_data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Warning: failed to load stw_safe_apis.json: {e}", file=sys.stderr)
+        _stw_data = {}
+    return _stw_data
+
+
+def _extract_apis_from_value(value: object) -> set[str]:
+    """Extract API names from a data-file value (list, or dict with sub-lists)."""
+    apis: set[str] = set()
+    if isinstance(value, list):
+        apis.update(value)
+    elif isinstance(value, dict):
+        for sub_val in value.values():
+            if isinstance(sub_val, list):
+                apis.update(sub_val)
+        # Conditional entries store the API name as the key (value is a
+        # human-readable condition string).
+        for sub_key, sub_val in value.items():
+            if isinstance(sub_val, str) and not sub_key.startswith("_"):
+                apis.add(sub_key)
+    return apis
+
+
+def _get_safe_apis() -> set[str]:
+    """All APIs classified safe during STW.
+
+    On 3.14+ free-threading builds allocation APIs are safe (GC runs only on the
+    eval breaker, not during allocation). Conditionally-safe exception APIs are
+    treated as safe by the scanner — the "no exception set" precondition cannot
+    be verified statically, so the agent triages them.
+    """
+    data = _load_stw_apis()
+    unsafe_section = data.get("unsafe_during_stw", {})
+    safe: set[str] = set()
+    for category in data.get("safe_during_stw", {}).values():
+        if isinstance(category, list):
+            safe.update(category)
+    # ``safe_allocation_on_314`` lives *inside* ``unsafe_during_stw`` in the data
+    # file (it documents the 3.14+ carve-out from the historically-unsafe alloc
+    # APIs), so it must be read from there — a top-level lookup silently misses
+    # it and the whole 3.14+ "allocation is safe" revision never takes effect.
+    alloc_314 = unsafe_section.get("safe_allocation_on_314", {})
+    safe_alloc = alloc_314.get("safe_if_builtin_types_only", [])
+    if isinstance(safe_alloc, list):
+        safe.update(safe_alloc)
+    exc = unsafe_section.get("exception_setting", {})
+    cond_safe = exc.get("conditionally_safe_during_stw", {})
+    if isinstance(cond_safe, dict):
+        for api_name in cond_safe:
+            if not api_name.startswith("_"):
+                safe.add(api_name)
+    return safe
+
+
+def _get_unsafe_apis() -> set[str]:
+    """All APIs classified unsafe during STW (safe wins on overlap)."""
+    data = _load_stw_apis()
+    unsafe: set[str] = set()
+    for category in data.get("unsafe_during_stw", {}).values():
+        unsafe.update(_extract_apis_from_value(category))
+    unsafe -= _get_safe_apis()
+    return unsafe
+
+
+def _get_unsafe_apis_for_propagation() -> set[str]:
+    """Unsafe APIs used for call-graph propagation (excludes STW control).
+
+    Excluding the ``stw_start`` category keeps a function that legitimately opens
+    a StopTheWorld region from being mislabelled "invokes Python".
+    """
+    data = _load_stw_apis()
+    unsafe: set[str] = set()
+    for cat_name, apis in data.get("unsafe_during_stw", {}).items():
+        if cat_name != "stw_start":
+            unsafe.update(_extract_apis_from_value(apis))
+    return unsafe
+
+
+def _get_unsafe_categories() -> dict[str, set[str]]:
+    """Unsafe APIs grouped by their data-file category (for reason reporting)."""
+    data = _load_stw_apis()
+    categories: dict[str, set[str]] = {}
+    for cat_name, apis in data.get("unsafe_during_stw", {}).items():
+        extracted = _extract_apis_from_value(apis)
+        if extracted:
+            categories[cat_name] = extracted
+    return categories
+
+
+def _classify_call(func_name: str, safe_apis: set[str], unsafe_apis: set[str]) -> str:
+    """Classify a single call as ``safe`` / ``unsafe`` / ``unknown``."""
+    if func_name in safe_apis:
+        return "safe"
+    if func_name in unsafe_apis:
+        return "unsafe"
+    if func_name in _C_STDLIB:
+        return "safe"
+    return "unknown"
+
+
+def _get_unsafe_reason(func_name: str, unsafe_categories: dict[str, set[str]]) -> str:
+    """Return the data-file category explaining why an API is unsafe."""
+    for cat_name, apis in unsafe_categories.items():
+        if func_name in apis:
+            return cat_name
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# STW region detection + call-graph propagation
+# ---------------------------------------------------------------------------
+
+
+def _find_stw_regions(body_text: str) -> list[tuple[int, int]]:
+    """Byte-offset ranges between StopTheWorld and the next StartTheWorld.
+
+    Offsets are relative to ``body_text``. Each Stop is paired with the first
+    Start that follows it.
+    """
+    regions: list[tuple[int, int]] = []
+    stops = list(_STOP_RE.finditer(body_text))
+    starts = list(_START_RE.finditer(body_text))
+    for s in stops:
+        for st in starts:
+            if st.start() > s.end():
+                regions.append((s.end(), st.start()))
+                break
+    return regions
+
+
+def _is_in_region(offset: int, regions: list[tuple[int, int]]) -> bool:
+    """True if ``offset`` falls within any (start, end) region."""
+    return any(start <= offset < end for start, end in regions)
+
+
+def _build_call_graph(
+    functions: list[dict], source_bytes: bytes
+) -> dict[str, list[str]]:
+    """Map each function name to the list of functions it calls (intra-file)."""
+    graph: dict[str, list[str]] = {}
+    for func in functions:
+        calls = find_calls_in_scope(func["body_node"], source_bytes)
+        graph[func["name"]] = [c["function_name"] for c in calls]
+    return graph
+
+
+def _propagate_stw_safety(
+    graph: dict[str, list[str]],
+    safe_apis: set[str],
+    unsafe_apis: set[str],
+) -> dict[str, str]:
+    """Propagate STW-safety through the call graph.
+
+    A function is unsafe if any transitive callee is unsafe, unknown if a callee
+    is unknown (and none is unsafe), otherwise safe. Recursive edges are treated
+    as safe to break the cycle.
+    """
+    classifications: dict[str, str] = {}
+
+    def classify(func_name: str, visited: set[str]) -> str:
+        if func_name in classifications:
+            return classifications[func_name]
+        if func_name in visited:
+            return "safe"  # recursion — break the cycle
+        visited.add(func_name)
+
+        if func_name not in graph:
+            result = _classify_call(func_name, safe_apis, unsafe_apis)
+            classifications[func_name] = result
+            return result
+
+        result = "safe"
+        for callee in graph[func_name]:
+            callee_class = classify(callee, visited)
+            if callee_class == "unsafe":
+                result = "unsafe"
+                break
+            if callee_class == "unknown" and result == "safe":
+                result = "unknown"
+
+        classifications[func_name] = result
+        return result
+
+    for func_name in graph:
+        classify(func_name, set())
+    return classifications
+
+
+def _check_stw_regions(
+    func: dict,
+    source_bytes: bytes,
+    tree,
+    classifications: dict[str, str],
+    safe_apis: set[str],
+    unsafe_apis: set[str],
+    unsafe_categories: dict[str, set[str]],
+) -> list[dict]:
+    """Flag unsafe / unclassified calls inside this function's STW regions."""
+    findings: list[dict] = []
+    body_node = func["body_node"]
+    body_text = get_node_text(body_node, source_bytes)
+    regions = _find_stw_regions(body_text)
+    if not regions:
+        return findings
+
+    for call in find_calls_in_scope(body_node, source_bytes):
+        call_name = call["function_name"]
+        if call_name in _STW_CONTROL:
+            continue
+        # Offset of the call relative to the body node (same frame as regions).
+        call_offset = call["start_byte"] - body_node.start_byte
+        if call_offset < 0 or not _is_in_region(call_offset, regions):
+            continue
+        if is_suppressed_by_comment(source_bytes, tree, call["start_line"]):
+            continue
+
+        # Prefer the propagated classification (covers local helpers); fall back
+        # to direct API classification for calls never reached by propagation.
+        call_class = classifications.get(call_name)
+        if call_class is None:
+            call_class = _classify_call(call_name, safe_apis, unsafe_apis)
+
+        if call_class == "safe":
+            continue
+
+        if call_class == "unsafe":
+            reason = _get_unsafe_reason(call_name, unsafe_categories)
+            if not reason or reason == "unknown":
+                reason = "transitively_invokes_python"
+
+            finding_type = "stw_unsafe_call"
+            if reason == "exception_setting":
+                finding_type = "stw_exception_during_stw"
+            elif reason == "may_trigger_gc_or_alloc":
+                finding_type = "stw_allocation_during_stw"
+
+            findings.append(
+                {
+                    "type": finding_type,
+                    "function": func["name"],
+                    "line": call["start_line"],
+                    "confidence": "high",
+                    "detail": (
+                        f"Unsafe call {call_name}() inside a _PyEval_StopTheWorld "
+                        f"region in '{func['name']}'. During STW every other thread "
+                        f"is suspended; this call may invoke Python code, set an "
+                        f"exception via the format machinery, or take a lock a "
+                        f"stopped thread holds — which can deadlock the world or "
+                        f"corrupt interpreter state on the free-threaded build. "
+                        f"Category: {reason}. Call _PyEval_StartTheWorld before it "
+                        f"(cf. Python/gc_free_threading.c:2223). Intra-file analysis: "
+                        f"transitive callees in other files are not followed."
+                    ),
+                    "api_call": call_name,
+                    "unsafe_reason": reason,
+                }
+            )
+
+        elif call_class == "unknown":
+            findings.append(
+                {
+                    "type": "stw_unknown_call",
+                    "function": func["name"],
+                    "line": call["start_line"],
+                    "confidence": "medium",
+                    "detail": (
+                        f"Unclassified call {call_name}() inside a "
+                        f"_PyEval_StopTheWorld region in '{func['name']}'. Cannot "
+                        f"statically determine whether it may invoke Python code — "
+                        f"it is not in the STW API vocabulary and (if local) its "
+                        f"body reaches an unclassified callee. Manual review needed. "
+                        f"Intra-file analysis only."
+                    ),
+                    "api_call": call_name,
+                }
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan CPython C source for StopTheWorld-safety violations."""
+    project_root, scan_root = resolve_roots(target)
+
+    safe_apis = _get_safe_apis()
+    unsafe_apis = _get_unsafe_apis()
+    unsafe_apis_for_prop = _get_unsafe_apis_for_propagation()
+    unsafe_categories = _get_unsafe_categories()
+
+    findings: list[dict] = []
+    files_analyzed = 0
+    functions_analyzed = 0
+    skipped: list[dict] = []
+    all_classifications: dict[str, dict[str, str]] = {}
+    stw_functions: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        functions_analyzed += len(functions)
+
+        # Only files that actually use StopTheWorld can have a violation.
+        source_text = source_bytes.decode("utf-8", errors="replace")
+        if "_PyEval_StopTheWorld" not in source_text:
+            continue
+
+        rel = relpath(filepath, project_root)
+        graph = _build_call_graph(functions, source_bytes)
+        classifications = _propagate_stw_safety(graph, safe_apis, unsafe_apis_for_prop)
+        all_classifications[rel] = classifications
+
+        for func in functions:
+            for f in _check_stw_regions(
+                func,
+                source_bytes,
+                tree,
+                classifications,
+                safe_apis,
+                unsafe_apis,
+                unsafe_categories,
+            ):
+                f["file"] = rel
+                findings.append(f)
+
+            if "_PyEval_StopTheWorld" in func["body"]:
+                stw_functions.append(
+                    {
+                        "file": rel,
+                        "function": func["name"],
+                        "line": func["start_line"],
+                        "classification": classifications.get(func["name"], "unknown"),
+                    }
+                )
+
+    by_type: dict[str, int] = defaultdict(int)
+    by_confidence: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=functions_analyzed,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_confidence": dict(by_confidence),
+            "stw_function_count": len(stw_functions),
+        },
+        stw_functions=stw_functions,
+        function_classifications=all_classifications,
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_known_issues.py
+++ b/tests/test_check_known_issues.py
@@ -151,11 +151,12 @@ class TestCheckKnownIssues(unittest.TestCase):
 
     # --- no_scanner passthrough --------------------------------------------
 
-    def test_no_scanner_categories_pass_through(self):
+    def test_no_scanner_category_passes_through(self):
+        # `init-bypass` has no scanner yet -> carried through as no_scanner.
+        # (`tsan` IS scanned now, by scan_ft_races.)
         report = self._run(
             {"Objects/present.c": _PRESENT_DEALLOC},
             [
-                ("TSAN-1", "Objects/present.c", 10, "tsan", "some_race", "data race"),
                 (
                     "INIT-1",
                     "Objects/present.c",
@@ -166,11 +167,10 @@ class TestCheckKnownIssues(unittest.TestCase):
                 ),
             ],
         )
-        self.assertEqual(self._result_for(report, "TSAN-1")["status"], "no_scanner")
         self.assertEqual(self._result_for(report, "INIT-1")["status"], "no_scanner")
-        self.assertEqual(report["bug_rollup"]["TSAN-1"], "no_scanner")
+        self.assertEqual(report["bug_rollup"]["INIT-1"], "no_scanner")
         # no_scanner entries are never scanned and never actionable findings.
-        self.assertFalse(any(f["bug_id"] == "TSAN-1" for f in report["findings"]))
+        self.assertFalse(any(f["bug_id"] == "INIT-1" for f in report["findings"]))
 
     # --- bug_rollup collapsing multi-site bugs -----------------------------
 

--- a/tests/test_parse_tsan_report.py
+++ b/tests/test_parse_tsan_report.py
@@ -1,0 +1,198 @@
+"""Tests for parse_tsan_report.py — TSan report triage over CPython's own source.
+
+Unlike the tree-sitter scanners, this parser consumes plain TSan text, so the
+fixtures are inline report blocks (no C project on disk required).
+"""
+
+import unittest
+
+from helpers import import_script
+
+# A race in CPython's own dict internals — the target. Two racing sites:
+# insertdict (write) and lookdict (read), both in Objects/dictobject.c.
+_CPYTHON_RACE = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=12345)
+  Write of size 8 at 0x7b0400000640 by thread T2:
+    #0 insertdict /home/py/cpython/Objects/dictobject.c:1123 (python3.14t+0x2a1b3c)
+    #1 dict_ass_sub /home/py/cpython/Objects/dictobject.c:2405 (python3.14t+0x2a2000)
+    #2 _PyEval_EvalFrameDefault /home/py/cpython/Python/ceval.c:5010 (python3.14t+0x3f0)
+
+  Previous read of size 8 at 0x7b0400000640 by thread T1:
+    #0 lookdict /home/py/cpython/Objects/dictobject.c:998 (python3.14t+0x2a1000)
+    #1 _PyEval_EvalFrameDefault /home/py/cpython/Python/ceval.c:5010 (python3.14t+0x3f0)
+
+  Location is heap block of size 232 at 0x7b0400000600 allocated by thread T1:
+    #0 malloc <null> (libtsan.so.2+0x2a2f9)
+    #1 _PyObject_Malloc /home/py/cpython/Objects/obmalloc.c:1234 (python3.14t+0x1a0000)
+
+  Thread T2 (tid=12347, running) created by main thread at:
+    #0 pthread_create <null> (libtsan.so.2+0x605b8)
+    #1 do_start_new_thread /home/py/cpython/Modules/_threadmodule.c:1567 (python3+0x4b0)
+
+SUMMARY: ThreadSanitizer: data race /home/py/cpython/Objects/dictobject.c:1123 in insertdict
+==================
+"""
+
+# A race whose frames are all pure thread scaffolding / libc — noise.
+_NOISE_RACE = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=12345)
+  Write of size 4 at 0x7b0800000010 by thread T5:
+    #0 start_thread <null> (libc.so.6+0x8944)
+    #1 clone <null> (libc.so.6+0x105bf)
+
+  Previous write of size 4 at 0x7b0800000010 by thread T4:
+    #0 start_thread <null> (libc.so.6+0x8944)
+    #1 clone <null> (libc.so.6+0x105bf)
+
+SUMMARY: ThreadSanitizer: data race /usr/lib/libc.so.6 in start_thread
+==================
+"""
+
+# A race in a CPython built-in test-harness module — noise (not the target).
+_TESTHARNESS_RACE = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=12345)
+  Write of size 8 at 0x7b0c00000020 by thread T3:
+    #0 test_racy_helper /home/py/cpython/Modules/_testcapimodule.c:4210 (_testcapi+0x99)
+
+  Previous read of size 8 at 0x7b0c00000020 by thread T2:
+    #0 test_racy_helper /home/py/cpython/Modules/_testcapimodule.c:4210 (_testcapi+0x99)
+
+SUMMARY: ThreadSanitizer: data race Modules/_testcapimodule.c:4210 in test_racy_helper
+==================
+"""
+
+
+class TestParseTsanReport(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("parse_tsan_report")
+
+    # --- core extraction ---------------------------------------------------
+
+    def test_extracts_two_racing_sites(self):
+        result = self.mod.parse_report(_CPYTHON_RACE)
+        self.assertEqual(result["total_warnings"], 1)
+        self.assertEqual(result["unique_races"], 1)
+        finding = result["findings"][0]
+        sites = {s["site"] for s in finding["sites"]}
+        self.assertEqual(sites, {"dictobject.c:insertdict", "dictobject.c:lookdict"})
+        # The two accesses are captured with their access types.
+        access_types = [a["access_type"] for a in finding["accesses"]]
+        self.assertEqual(len(access_types), 2)
+        self.assertTrue(any("Write" in t for t in access_types))
+        self.assertTrue(any("read" in t.lower() for t in access_types))
+
+    def test_signature_is_unordered_site_pair(self):
+        result = self.mod.parse_report(_CPYTHON_RACE)
+        # Sorted, so the signature is order-independent.
+        self.assertEqual(
+            result["findings"][0]["signature"],
+            "dictobject.c:insertdict | dictobject.c:lookdict",
+        )
+
+    # --- deduplication -----------------------------------------------------
+
+    def test_two_identical_races_dedup_to_one(self):
+        result = self.mod.parse_report(_CPYTHON_RACE + _CPYTHON_RACE)
+        self.assertEqual(result["total_warnings"], 2)
+        self.assertEqual(result["unique_races"], 1)
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["frequency"], 2)
+
+    # --- the key inversion: CPython frame = target, scaffolding = noise ----
+
+    def test_cpython_frame_race_is_target(self):
+        result = self.mod.parse_report(_CPYTHON_RACE)
+        finding = result["findings"][0]
+        self.assertTrue(finding["is_cpython_race"])
+        self.assertFalse(finding["is_noise"])
+        self.assertEqual(result["cpython_races"], 1)
+        self.assertEqual(result["noise_races"], 0)
+        self.assertEqual(result["summary"]["actionable"], 1)
+
+    def test_scaffolding_only_race_is_noise(self):
+        result = self.mod.parse_report(_NOISE_RACE)
+        finding = result["findings"][0]
+        self.assertFalse(finding["is_cpython_race"])
+        self.assertTrue(finding["is_noise"])
+        self.assertEqual(result["cpython_races"], 0)
+        self.assertEqual(result["noise_races"], 1)
+
+    def test_test_harness_module_race_is_noise(self):
+        # A frame in Modules/_testcapimodule.c is under Modules/ but is
+        # test-harness scaffolding, so noise must win over the CPython-source
+        # path match.
+        result = self.mod.parse_report(_TESTHARNESS_RACE)
+        finding = result["findings"][0]
+        self.assertTrue(finding["is_noise"])
+        self.assertFalse(finding["is_cpython_race"])
+
+    def test_mixed_report_separates_target_from_noise(self):
+        result = self.mod.parse_report(
+            _CPYTHON_RACE + _CPYTHON_RACE + _NOISE_RACE + _TESTHARNESS_RACE
+        )
+        self.assertEqual(result["total_warnings"], 4)
+        self.assertEqual(result["unique_races"], 3)
+        self.assertEqual(result["cpython_races"], 1)
+        self.assertEqual(result["noise_races"], 2)
+
+    # --- classification ----------------------------------------------------
+
+    def test_write_read_race_is_high(self):
+        result = self.mod.parse_report(_CPYTHON_RACE)
+        finding = result["findings"][0]
+        self.assertEqual(finding["classification"], "RACE")
+        self.assertEqual(finding["severity"], "HIGH")
+
+    def test_global_variable_race_is_critical(self):
+        global_race = _CPYTHON_RACE.replace(
+            "Location is heap block", "Location is global 'interp_state'"
+        )
+        result = self.mod.parse_report(global_race)
+        self.assertEqual(result["findings"][0]["severity"], "CRITICAL")
+
+    # --- envelope / summary shape ------------------------------------------
+
+    def test_envelope_shape(self):
+        result = self.mod.parse_report(_CPYTHON_RACE)
+        for key in (
+            "total_warnings",
+            "unique_races",
+            "cpython_races",
+            "noise_races",
+            "findings",
+            "summary",
+            "findings_repo",
+        ):
+            self.assertIn(key, result)
+        self.assertEqual(result["findings_repo"], "cpython-tsan-findings")
+        summary = result["summary"]
+        for key in ("total_findings", "by_classification", "by_severity", "actionable"):
+            self.assertIn(key, summary)
+
+    def test_empty_report_is_clean(self):
+        result = self.mod.parse_report("no thread sanitizer output here\n")
+        self.assertEqual(result["total_warnings"], 0)
+        self.assertEqual(result["unique_races"], 0)
+        self.assertEqual(result["findings"], [])
+
+    def test_analyze_reads_file(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "tsan.txt"
+            p.write_text(_CPYTHON_RACE, encoding="utf-8")
+            result = self.mod.analyze(str(p))
+        self.assertIn("report_path", result)
+        self.assertEqual(result["cpython_races"], 1)
+
+    def test_analyze_missing_file_errors(self):
+        result = self.mod.analyze("/nonexistent/tsan_report_xyz.txt")
+        self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_ft_races.py
+++ b/tests/test_scan_ft_races.py
@@ -1,0 +1,244 @@
+"""Tests for scan_ft_races.py — free-threading data races (T1/T2/T3)."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanFtRaces(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_ft_races")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    # --- T3: iterator-exhaustion double-DECREF -----------------------------
+
+    def test_t3_iternext_pyclear_without_lock_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/myiter.c": (
+                    "static PyObject *\n"
+                    "myiter_iternext(PyObject *self)\n"
+                    "{\n"
+                    "    MyIter *it = (MyIter *)self;\n"
+                    "    if (it->it_seq == NULL) return NULL;\n"
+                    "    if (exhausted(it)) {\n"
+                    "        Py_CLEAR(it->it_seq);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    return next_item(it);\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["type"] == "iternext_double_decref"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["ft_class"], "T3")
+        self.assertEqual(f["confidence"], "high")
+
+    def test_t3_setnull_decref_without_lock_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/myiter.c": (
+                    "static PyObject *\n"
+                    "myiter_iternext(PyObject *self)\n"
+                    "{\n"
+                    "    MyIter *it = (MyIter *)self;\n"
+                    "    PyObject *seq = it->it_seq;\n"
+                    "    if (done(it)) {\n"
+                    "        it->it_seq = NULL;\n"
+                    "        Py_DECREF(seq);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    return next_item(it);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertTrue(
+            any(f["type"] == "iternext_double_decref" for f in result["findings"])
+        )
+
+    def test_t3_iternext_with_critical_section_is_suppressed(self):
+        result = self._findings(
+            {
+                "Objects/myiter.c": (
+                    "static PyObject *\n"
+                    "myiter_iternext(PyObject *self)\n"
+                    "{\n"
+                    "    MyIter *it = (MyIter *)self;\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    Py_CLEAR(it->it_seq);\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return NULL;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual([f for f in result["findings"] if f["ft_class"] == "T3"], [])
+
+    def test_t3_non_iternext_is_not_flagged(self):
+        result = self._findings(
+            {
+                "Objects/myiter.c": (
+                    "static void\n"
+                    "myiter_dealloc(PyObject *self)\n"
+                    "{\n"
+                    "    MyIter *it = (MyIter *)self;\n"
+                    "    Py_CLEAR(it->it_seq);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual([f for f in result["findings"] if f["ft_class"] == "T3"], [])
+
+    # --- T2: lazy-init without a critical section --------------------------
+
+    def test_t2_lazy_init_without_lock_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/descr.c": (
+                    "static PyObject *\n"
+                    "descr_get_qualname(PyObject *self)\n"
+                    "{\n"
+                    "    MyDescr *descr = (MyDescr *)self;\n"
+                    "    if (descr->d_qualname == NULL)\n"
+                    "        descr->d_qualname = calculate_qualname(descr);\n"
+                    "    return Py_XNewRef(descr->d_qualname);\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (
+                f
+                for f in result["findings"]
+                if f["type"] == "lazy_init_no_critical_section"
+            ),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["ft_class"], "T2")
+        self.assertEqual(f["member"], "descr->d_qualname")
+
+    def test_t2_bang_form_is_flagged(self):
+        result = self._findings(
+            {
+                "Objects/x.c": (
+                    "static PyObject *\n"
+                    "get_cache(PyObject *self)\n"
+                    "{\n"
+                    "    Foo *f = (Foo *)self;\n"
+                    "    if (!f->cache) {\n"
+                    "        f->cache = build_cache(f);\n"
+                    "    }\n"
+                    "    return f->cache;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertTrue(
+            any(
+                f["type"] == "lazy_init_no_critical_section" for f in result["findings"]
+            )
+        )
+
+    def test_t2_with_critical_section_is_suppressed(self):
+        result = self._findings(
+            {
+                "Objects/x.c": (
+                    "static PyObject *\n"
+                    "get_cache(PyObject *self)\n"
+                    "{\n"
+                    "    Foo *f = (Foo *)self;\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    if (f->cache == NULL)\n"
+                    "        f->cache = build_cache(f);\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return f->cache;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual([f for f in result["findings"] if f["ft_class"] == "T2"], [])
+
+    def test_t2_null_check_without_assignment_is_not_flagged(self):
+        result = self._findings(
+            {
+                "Objects/x.c": (
+                    "static PyObject *\n"
+                    "get_thing(PyObject *self)\n"
+                    "{\n"
+                    "    Foo *f = (Foo *)self;\n"
+                    "    if (f->thing == NULL)\n"
+                    "        return NULL;\n"
+                    "    return f->thing;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual([f for f in result["findings"] if f["ft_class"] == "T2"], [])
+
+    # --- T1: atomic/plain access asymmetry ---------------------------------
+
+    def test_t1_atomic_plain_asymmetry_is_flagged(self):
+        result = self._findings(
+            {
+                "Modules/counter.c": (
+                    "static PyObject *\n"
+                    "count_next(CountObject *lz)\n"
+                    "{\n"
+                    "    Py_ssize_t c = FT_ATOMIC_LOAD_SSIZE_RELAXED(lz->cnt);\n"
+                    "    return PyLong_FromSsize_t(c);\n"
+                    "}\n"
+                    "static PyObject *\n"
+                    "count_repr(CountObject *lz)\n"
+                    "{\n"
+                    '    return PyUnicode_FromFormat("count(%zd)", lz->cnt);\n'
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["type"] == "atomic_plain_asymmetry"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["ft_class"], "T1")
+        self.assertEqual(f["member"], "cnt")
+
+    def test_t1_all_atomic_is_not_flagged(self):
+        result = self._findings(
+            {
+                "Modules/counter.c": (
+                    "static void bump(CountObject *lz)\n"
+                    "{\n"
+                    "    FT_ATOMIC_STORE_SSIZE_RELAXED(lz->cnt, "
+                    "FT_ATOMIC_LOAD_SSIZE_RELAXED(lz->cnt) + 1);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual([f for f in result["findings"] if f["ft_class"] == "T1"], [])
+
+    def test_envelope_shape(self):
+        result = self._findings({"Objects/x.c": "static void f(void) { }\n"})
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+        self.assertIn("by_class", result["summary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_lock_discipline.py
+++ b/tests/test_scan_lock_discipline.py
@@ -1,0 +1,269 @@
+"""Tests for scan_lock_discipline.py — critical-section / lock discipline."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanLockDiscipline(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_lock_discipline")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    def _types(self, result):
+        return [f["type"] for f in result["findings"]]
+
+    # --- true positives ----------------------------------------------------
+
+    def test_early_return_before_end_is_flagged(self):
+        # Py_BEGIN_CRITICAL_SECTION with an early return before the END: the
+        # per-object lock leaks on the error path.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_method(PyObject *self)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    if (bad(self)) {\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return self;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertIn("critical_section_end_on_error", self._types(result))
+        f = next(
+            f
+            for f in result["findings"]
+            if f["type"] == "critical_section_end_on_error"
+        )
+        self.assertEqual(f["function"], "foo_method")
+        self.assertEqual(f["classification"], "FIX")
+        self.assertEqual(f["line"], 6)  # the `return NULL;` line
+
+    def test_missing_end_is_flagged(self):
+        # A begin with no matching END anywhere: never released.
+        result = self._findings(
+            {
+                "Objects/bar.c": (
+                    "static PyObject *\n"
+                    "bar_method(PyObject *self)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    PyObject *r = compute(self);\n"
+                    "    return r;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertIn("critical_section_missing_end", self._types(result))
+        # The unbalanced begin must not *also* be double-reported as an
+        # end-on-error for the same return.
+        self.assertNotIn("critical_section_end_on_error", self._types(result))
+
+    def test_goto_out_of_section_is_flagged(self):
+        # goto to a label that lives *after* the END skips the release.
+        result = self._findings(
+            {
+                "Objects/baz.c": (
+                    "static int\n"
+                    "baz_method(PyObject *self)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    if (err(self)) goto cleanup;\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "cleanup:\n"
+                    "    return -1;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertIn("critical_section_end_on_error", self._types(result))
+
+    def test_nested_different_objects_is_consider(self):
+        result = self._findings(
+            {
+                "Objects/qux.c": (
+                    "static PyObject *\n"
+                    "qux_merge(PyObject *a, PyObject *b)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(a);\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(b);\n"
+                    "    do_merge(a, b);\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return a;\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["type"] == "nested_critical_sections"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["classification"], "CONSIDER")
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_properly_paired_is_clean(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_get(PyObject *self)\n"
+                    "{\n"
+                    "    PyObject *r;\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    r = load(self);\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return r;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_end_before_early_return_is_clean(self):
+        # Releasing before the early return is the correct idiom — no finding.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_get(PyObject *self)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    if (bad(self)) {\n"
+                    "        Py_END_CRITICAL_SECTION();\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return self;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_retry_goto_within_section_is_clean(self):
+        # A goto whose target label is *inside* the section is an internal
+        # jump (retry loop), not an exit — must not be flagged.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_spin(PyObject *self)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "retry:\n"
+                    "    if (again(self)) goto retry;\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return self;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_no_critical_section_is_clean(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "plain(PyObject *self)\n"
+                    "{\n"
+                    "    if (bad(self)) return NULL;\n"
+                    "    return self;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "foo_method(PyObject *self)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION(self);\n"
+                    "    if (bad(self)) {\n"
+                    "        /* intentional: lock released by caller */\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return self;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    # --- CPython-specific edge: the _MUTEX spelling ------------------------
+
+    def test_mutex_begin_spelling_is_handled(self):
+        # Py_BEGIN_CRITICAL_SECTION_MUTEX(&m) must be recognized as a begin
+        # (paired with the ordinary Py_END_CRITICAL_SECTION()).
+        result = self._findings(
+            {
+                "Modules/m.c": (
+                    "static int\n"
+                    "m_op(state *st)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION_MUTEX(&st->mutex);\n"
+                    "    if (fail(st)) {\n"
+                    "        return -1;\n"
+                    "    }\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return 0;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertIn("critical_section_end_on_error", self._types(result))
+
+    def test_mutex_begin_properly_paired_is_clean(self):
+        result = self._findings(
+            {
+                "Modules/m.c": (
+                    "static int\n"
+                    "m_op(state *st)\n"
+                    "{\n"
+                    "    Py_BEGIN_CRITICAL_SECTION_MUTEX(&st->mutex);\n"
+                    "    touch(st);\n"
+                    "    Py_END_CRITICAL_SECTION();\n"
+                    "    return 0;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    # --- envelope shape ----------------------------------------------------
+
+    def test_envelope_shape(self):
+        result = self._findings({"Objects/foo.c": "static void foo(void) { }\n"})
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+        self.assertIn("total_findings", result["summary"])
+        self.assertIn("by_type", result["summary"])
+        self.assertIn("by_classification", result["summary"])
+        self.assertIn("critical_section_functions", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_stw_safety.py
+++ b/tests/test_scan_stw_safety.py
@@ -1,0 +1,234 @@
+"""Tests for scan_stw_safety.py — StopTheWorld-safety in CPython's own code.
+
+The scanner reviews CPython's ``Python/`` / ``Objects/`` / ``Modules/`` code:
+an unsafe call inside a real ``_PyEval_StopTheWorld()..._PyEval_StartTheWorld()``
+region can deadlock the world or corrupt interpreter state on the free-threaded
+build. Note the data-file revision (2026-04-04) reclassified object allocation
+(``PyList_New`` etc.) and ``PyErr_NoMemory`` as *conditionally safe* on 3.14+, so
+those are intentionally NOT flagged; the unambiguous violations below are
+Python-invoking calls (``PyObject_Str``), the exception format machinery
+(``PyErr_Format``), and container mutation.
+"""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanStwSafety(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_stw_safety")
+
+    def _analyze(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    # --- true positives ----------------------------------------------------
+
+    def test_unsafe_call_in_stw_region_is_flagged(self):
+        result = self._analyze(
+            {
+                "Modules/worker.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "stw_worker(PyInterpreterState *interp, PyObject *obj)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    "    PyObject_Str(obj);\n"
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["api_call"] == "PyObject_Str"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["type"], "stw_unsafe_call")
+        self.assertEqual(f["function"], "stw_worker")
+        self.assertEqual(f["confidence"], "high")
+        self.assertEqual(f["unsafe_reason"], "invokes_python_code")
+        self.assertEqual(f["file"], "Modules/worker.c")
+
+    def test_exception_format_in_stw_region_is_exception_type(self):
+        result = self._analyze(
+            {
+                "Python/thing.c": (
+                    "static void\n"
+                    "stw_err(PyInterpreterState *interp)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    '    PyErr_Format(PyExc_RuntimeError, "boom");\n'
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["api_call"] == "PyErr_Format"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["type"], "stw_exception_during_stw")
+        self.assertEqual(f["unsafe_reason"], "exception_setting")
+
+    def test_transitive_unsafe_helper_in_region_is_flagged(self):
+        # The STW region calls a local helper that is itself unsafe (it invokes
+        # Python). Intra-file propagation must mark the helper unsafe and flag
+        # the call to it during STW.
+        result = self._analyze(
+            {
+                "Objects/graph.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "unsafe_helper(PyObject *obj)\n"
+                    "{\n"
+                    '    PyObject_GetAttrString(obj, "x");\n'
+                    "}\n"
+                    "static void\n"
+                    "stw_caller(PyInterpreterState *interp, PyObject *obj)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    "    unsafe_helper(obj);\n"
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "}\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["api_call"] == "unsafe_helper"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["type"], "stw_unsafe_call")
+        self.assertEqual(f["function"], "stw_caller")
+        self.assertEqual(f["unsafe_reason"], "transitively_invokes_python")
+        # And the helper is recorded as unsafe in the propagated classifications.
+        self.assertEqual(
+            result["function_classifications"]["Objects/graph.c"]["unsafe_helper"],
+            "unsafe",
+        )
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_safe_ops_in_region_not_flagged(self):
+        result = self._analyze(
+            {
+                "Objects/safe.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "stw_safe(PyInterpreterState *interp, PyObject *lst, char *dst,\n"
+                    "         char *src, Py_ssize_t n)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    "    PyObject *item = PyList_GET_ITEM(lst, 0);\n"
+                    "    Py_INCREF(item);\n"
+                    "    memcpy(dst, src, n);\n"
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+        # It is still recorded as an STW-bearing function.
+        self.assertEqual(result["summary"]["stw_function_count"], 1)
+
+    def test_builtin_allocation_in_region_is_safe_on_314(self):
+        # PyTuple_New/PyList_New during STW is SAFE on 3.14+ free-threading
+        # builds (GC runs only on the eval breaker, not during allocation).
+        # This is exactly what CPython's own _PyEval_SetProfileAllThreads does:
+        # PyTuple_New inside the StopTheWorld region. The data-file revision
+        # (safe_allocation_on_314) must suppress it — regression guard against
+        # the nested-key lookup silently missing that carve-out.
+        result = self._analyze(
+            {
+                "Python/prof.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "stw_alloc(PyInterpreterState *interp, Py_ssize_t n)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    "    PyObject *t = PyTuple_New(n);\n"
+                    "    (void)t;\n"
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_unsafe_call_without_stw_region_not_flagged(self):
+        result = self._analyze(
+            {
+                "Objects/plain.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "plain(PyObject *obj)\n"
+                    "{\n"
+                    "    PyObject_Str(obj);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+        self.assertEqual(result["summary"]["stw_function_count"], 0)
+
+    def test_unsafe_call_after_start_the_world_not_flagged(self):
+        # The correct pattern: do the unsafe work AFTER StartTheWorld.
+        result = self._analyze(
+            {
+                "Python/correct.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "stw_correct(PyInterpreterState *interp, PyObject *obj)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    "    Py_INCREF(obj);\n"
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "    PyObject_Str(obj);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    # --- suppression + envelope --------------------------------------------
+
+    def test_comment_suppression(self):
+        result = self._analyze(
+            {
+                "Modules/sup.c": (
+                    '#include "Python.h"\n'
+                    "static void\n"
+                    "stw_sup(PyInterpreterState *interp, PyObject *obj)\n"
+                    "{\n"
+                    "    _PyEval_StopTheWorld(interp);\n"
+                    "    /* intentional: type is a builtin, no exception is set */\n"
+                    "    PyObject_Str(obj);\n"
+                    "    _PyEval_StartTheWorld(interp);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_envelope_shape(self):
+        result = self._analyze(
+            {"Objects/foo.c": "static void foo(PyObject *self) { }\n"}
+        )
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+            "stw_functions",
+            "function_classifications",
+        ):
+            self.assertIn(key, result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **ft-race-scanner** + `scan_ft_races.py` — the three most mechanically-detectable TSan race classes in CPython's own free-threaded code: T3 iterator-exhaustion double-DECREF (gh-154130/gh-144357/gh-153296), T2 lazy-init cache without a critical section (TSAN-0043 `descr_get_qualname`), T1 atomic/plain access asymmetry (TSAN-0006 `count_repr`). Suppresses the `*_lock_held` caller-holds-the-lock convention.
- **stw-safety-checker**, **lock-discipline-checker**, **tsan-report-analyzer** + **tsan-stress-generator** — ported from ft-review-toolkit (which was calibrated against CPython's own runtime) and adapted: the tsan-report-analyzer's extension-oriented "filter CPython frames" logic is *inverted* (CPython-source races ARE the target).
- FT data files (`stw_safe_apis.json`, `lock_macros.json`, `critical_section_apis.json`, `atomic_patterns.json`); `known-issues` now scans the `tsan` catalog category (was `no_scanner`).
- Wired into `explore` (Group B2) and `health`; version → 0.6.0.

Tight, validated whole-tree S/N — ft-races on Objects/: T1:14/T2:7/T3:3; lock-discipline on Objects/: 1 finding across 207 critical-section functions; stw-safety surfaces real candidates in `instrumentation.c`/`pystate.c`. The stw-safety port also fixed a latent bug in the ft reference (`safe_allocation_on_314` key path).

## Test plan
- [x] `python -m unittest discover tests` — **202 tests green** (was 157; +45 across the four detectors)
- [x] `mypy` clean on all authored scripts; `ruff` clean (repo-baseline EXE001 / noqa'd BLE001 only)
- [x] Smoke-run each detector on a live CPython checkout; confirmed `descr_get_qualname` (TSAN-0043) → present via `known-issues`
- [x] `tree_sitter_utils.py` still byte-identical to the cext source; FT data files byte-identical to ft

Deferred to v0.7 (see `docs/improvement-plan.md`): the `set_nomemory` reproducer harness + actually reproducing these static findings under TSan on a `--disable-gil` build.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Ko7pYv9LY8wCj87eMH93oD