### PR TITLE
v0.7: OOM reproducer harness + init-bypass / parity checkers + memory-pattern scanner

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "cpython-review-toolkit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CPython C code exploration and analysis toolkit: specialized agents for refcount auditing, error path analysis, GIL discipline, NULL safety, complexity, include-graph mapping, PEP 7 style, deprecation, macros, and memory patterns \u2014 plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
   "owner": {
     "name": "Danzin",
@@ -12,7 +12,7 @@
       "name": "cpython-review-toolkit",
       "description": "Specialized agents and commands for exploring, analyzing, and reviewing CPython's C source code. Regex scanners for include-graph mapping, complexity, refcounts, error paths, GIL, and NULL safety, plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command.",
       "source": "./plugins/cpython-review-toolkit",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "code-quality",
       "keywords": [
         "cpython",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.7.0] - 2026-07-24
+
+The dynamic-verification release. Adds the harness that turns a *static*
+candidate into a *reproduced* crash, plus the two remaining static detectors
+whose designs were already written down, and a differential oracle built from
+CPython's own shipped dual implementations.
+
+### Added
+- **oom-reproducer** + `run_oom_sweep.py` + the **`reproduce`** command: dense
+  `_testcapi.set_nomemory` OOM injection with one subprocess per iteration and
+  exit-code classification (139/-11 SIGSEGV, 134/-6 SIGABRT, 1 = a clean
+  `MemoryError` — the *safe* outcome). This is the technique that already found
+  gh-146092 (`_PyFrame_GetLocals`) by hand. Validated against a local CPython
+  build: abort detection confirmed end-to-end; the interpreter guard rejects a
+  python without `_testcapi`.
+- **parity-checker** + `find_parity_pairs.py`: CPython *ships* pure-Python twins
+  of several C accelerators (`_pydecimal`, `_pyio`, `_pydatetime`, …), which are
+  a free differential oracle — if the C side crashes where the twin raises, the
+  bug is confirmed and localized. Discovery finds 39 pairs on the current tree
+  (6 high-confidence).
+- **init-bypass-checker** + `scan_init_bypass.py`: builds the design in
+  `docs/python-wrapper-new-without-init.md` for the C side — a slot reads
+  `self->field` and INCREFs/calls/derefs it with no NULL guard on a type whose
+  `tp_new` doesn't guarantee initialization, or whose field is deletable
+  (gh-152954, gh-152817).
+- **memory-pattern-analyzer promoted to a real scanner** (`scan_memory_patterns.py`):
+  integer overflow in an allocation size from a Python-controlled multiply
+  (gh-3493, gh-1779) and the GC-track invariant (gh-152107); previously
+  qualitative-only. The patterns the script cannot cover stay documented as an
+  explicit by-hand phase.
+
+### Changed
+- `known-issues`: the `init-bypass` category is now scanned, closing the last
+  `no_scanner` gap in the catalog.
+- `explore` / `health` / `hotspots` wire the new agents; version → 0.7.0.
+
 ## [0.6.0] - 2026-07-24
 
 The free-threading release. Uses the v0.5 tree-sitter chassis to add data-race

--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ Navigate to a CPython source checkout, then:
 /cpython-review-toolkit:hotspots       # Crash-class detectors + refcount + complexity
 /cpython-review-toolkit:explore        # Full exploration (all agents)
 /cpython-review-toolkit:known-issues   # Regression check vs the known-crash catalog
+/cpython-review-toolkit:reproduce      # Turn a static candidate into a reproduced crash
 ```
 
 Start with `map` to understand the include graph, then `hotspots` to find the highest-impact bugs.
 
 ## What's Included
 
-- **20 analysis agents** covering reference counting, error handling, GIL discipline, complexity, NULL safety, PEP 7 style, include dependencies, API deprecation, macro hygiene, memory patterns, and temporal history — plus tree-sitter-based **crash-class detectors** (recursion-guard gaps, destructor exception-clobber, uninitialized-dealloc) and **free-threading / data-race detectors** (iterator double-DECREF, stop-the-world safety, lock discipline, TSan triage).
-- **6 commands** (`explore`, `informed-explore`, `known-issues`, `map`, `hotspots`, `health`) for different analysis workflows.
+- **23 analysis agents** covering reference counting, error handling, GIL discipline, complexity, NULL safety, PEP 7 style, include dependencies, API deprecation, macro hygiene, memory patterns, and temporal history — plus tree-sitter-based **crash-class detectors** (recursion-guard gaps, destructor exception-clobber, uninitialized-dealloc, init-bypass), **free-threading / data-race detectors** (iterator double-DECREF, stop-the-world safety, lock discipline, TSan triage), a **differential parity checker** against CPython's own shipped pure-Python twins, and an **OOM reproducer** that turns a static candidate into a confirmed crash.
+- **7 commands** (`explore`, `informed-explore`, `known-issues`, `reproduce`, `map`, `hotspots`, `health`) for different analysis workflows.
 - **Analysis scripts** — stdlib-only regex scanners for the legacy dimensions, plus tree-sitter crash-class detectors, a `known-issues` regression checker, and an `informed-explore` briefing generator.
 
 ## Prerequisites
@@ -57,7 +58,9 @@ Start with `map` to understand the include graph, then `hotspots` to find the hi
 
 ## How It Works
 
-Two generations of scanner coexist: stdlib-only **regex scanners** for the legacy dimensions (refcounts, errors, NULL, GIL, complexity, PEP 7, includes), and **tree-sitter crash-class detectors** that parse a real C syntax tree to target specific reachable-from-Python crash classes (validated against confirmed CPython crashes). All scripts report candidates — expect 10-50% false positives depending on the detector — and the agents read the actual code to confirm or dismiss each finding and classify it FIX / CONSIDER / POLICY / ACCEPTABLE.
+Two generations of scanner coexist: stdlib-only **regex scanners** for the legacy dimensions (refcounts, errors, NULL, GIL, complexity, PEP 7, includes), and **tree-sitter detectors** that parse a real C syntax tree to target specific reachable-from-Python crash and data-race classes (validated against confirmed CPython crashes). All scripts report candidates — expect 10-50% false positives depending on the detector — and the agents read the actual code to confirm or dismiss each finding and classify it FIX / CONSIDER / POLICY / ACCEPTABLE.
+
+Beyond static analysis, the **`reproduce`** command closes the loop: it runs real `_testcapi.set_nomemory` OOM sweeps against a locally-built CPython to turn a static candidate into a reproduced crash — with the discipline that a *non*-reproduction is reported honestly and does not by itself refute the finding.
 
 For detailed usage, agent descriptions, and recommended workflows, see the [plugin README](plugins/cpython-review-toolkit/README.md).
 

--- a/plugins/cpython-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/cpython-review-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cpython-review-toolkit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CPython C code exploration and analysis agents: refcount auditing, error path analysis, GIL discipline, C complexity, include-graph mapping, PEP 7 style, NULL safety, deprecation, macros, and memory patterns \u2014 plus tree-sitter-based crash-class detectors (recursion-guard, destructor exception-clobber, uninitialized-dealloc), an informed-explore loop, and a known-issues regression command",
   "author": {
     "name": "Danzin"

--- a/plugins/cpython-review-toolkit/README.md
+++ b/plugins/cpython-review-toolkit/README.md
@@ -48,7 +48,7 @@ claude --plugin-dir cpython-review-toolkit/plugins/cpython-review-toolkit
 
 - **Claude Code** installed and running.
 - **Python 3.10+** for the analysis scripts (type union syntax, match statements).
-- **tree-sitter + tree-sitter-c** (`pip install tree-sitter tree-sitter-c`) — required by the tree-sitter-based crash-class detectors (`recursion-guard`, `pyerr-clear`, `uninit-dealloc`), the `known-issues` command, and the `informed-explore` briefing. The legacy regex scanners (refcounts, error-paths, null-safety, GIL, complexity, PEP 7, includes) remain stdlib-only.
+- **tree-sitter + tree-sitter-c** (`pip install tree-sitter tree-sitter-c`) — required by the tree-sitter-based detectors (`recursion-guard`, `pyerr-clear`, `uninit-dealloc`, `init-bypass`, the free-threading trio, `memory`), the `known-issues` command, and the `informed-explore` briefing. The legacy regex scanners (refcounts, error-paths, null-safety, GIL, complexity, PEP 7, includes) remain stdlib-only.
 
 ## Commands
 
@@ -70,7 +70,7 @@ The primary command. Runs the include-graph-mapper first for structural context,
 /cpython-review-toolkit:explore . all summary
 ```
 
-**Aspects**: `includes`, `refcounts`, `errors`, `gil`, `complexity`, `style`, `null-safety`, `deprecation`, `macros`, `memory`, `recursion`, `pyerr-clear`, `uninit-dealloc`, `history`, `all`
+**Aspects**: `includes`, `refcounts`, `errors`, `gil`, `complexity`, `style`, `null-safety`, `deprecation`, `macros`, `memory`, `recursion`, `pyerr-clear`, `uninit-dealloc`, `ft-races`, `stw-safety`, `lock-discipline`, `init-bypass`, `parity`, `history`, `all`
 
 **Options**: `deep` (full detail), `summary` (top-level only), `parallel` (concurrent agents)
 
@@ -118,6 +118,19 @@ A catalog-seeded targeted pass. Builds a briefing from `data/cpython_bug_shapes.
 /cpython-review-toolkit:informed-explore Objects/
 ```
 
+### `/cpython-review-toolkit:reproduce [finding-or-snippet] [--python <build>]`
+
+Turn a static allocation-failure candidate into a **reproduced crash**. Runs a
+dense `_testcapi.set_nomemory` sweep (one subprocess per allocation index) on a
+locally-built CPython and classifies each outcome — `segv`/`abort` = reproduced,
+`memory_error` = the failure was handled correctly (the safe outcome). Needs a
+build providing `_testcapi.set_nomemory`; a debug or ASan build is best.
+
+```bash
+/cpython-review-toolkit:reproduce Objects/templateobject.c:225
+/cpython-review-toolkit:reproduce 'import json; json.loads("[1,2]")' --python ~/projects/cpython/python
+```
+
 ## Agents
 
 ### Safety-Critical (script-backed)
@@ -140,6 +153,7 @@ These target specific reachable-from-Python crash classes grounded in the fusil 
 | **recursion-guard-auditor** | Recursion-prone slots (`tp_hash`/`tp_richcompare`/`tp_repr`/`tp_str`, generic-alias parameter walks) that descend a user-controlled object graph without `Py_EnterRecursiveCall`/`Py_ReprEnter` → native-stack-overflow SIGSEGV (gh-154318, gh-154275) | `scan_recursion_guards.py` |
 | **pyerr-clear-auditor** | `PyErr_Clear()` in the destructor family (`tp_dealloc`/`tp_clear`/`tp_finalize`/`tp_traverse`) with no save/restore, swallowing an in-flight `MemoryError`/`KeyboardInterrupt` (gh-152083) | `scan_pyerr_clear.py` |
 | **uninitialized-dealloc-auditor** | Non-zeroing allocation freed on an error path before members are NULL-initialized → `tp_dealloc` reads garbage (gh-151815, gh-152851) | `scan_uninit_dealloc.py` |
+| **init-bypass-checker** | A slot reads `self->field` and INCREFs/calls/derefs it with no NULL guard, where `__new__` can bypass `tp_init` or the member is deletable (gh-152954, gh-152817) | `scan_init_bypass.py` |
 
 ### Free-Threading / Data Races (tree-sitter based)
 
@@ -159,6 +173,13 @@ Not part of the static explore pipeline; these consume/produce a ThreadSanitizer
 |-------|--------------|--------|
 | **tsan-report-analyzer** | Parses/dedups a TSan report; for CPython, races in CPython's own frames ARE the target (the extension-oriented filter is inverted) | `parse_tsan_report.py` |
 | **tsan-stress-generator** | Emits a concurrent stress script that hammers a shared stdlib object under `PYTHON_GIL=0` to trigger races | — (prompt) |
+| **oom-reproducer** | Dense `_testcapi.set_nomemory` sweep (one subprocess per index) that turns a static allocation-failure candidate into a **reproduced** crash — or an honest negative. See the `reproduce` command | `run_oom_sweep.py` |
+
+### Differential (parity)
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **parity-checker** | Behavioral divergence between a C accelerator and its shipped pure-Python twin (`_decimal`/`_pydecimal`, `_io`/`_pyio`, `_datetime`/`_pydatetime`, …). A C crash where the twin raises is a confirmed, localized bug — CPython ships its own oracle | `find_parity_pairs.py` |
 
 ### Code Quality (script-backed)
 
@@ -176,7 +197,14 @@ These agents search the codebase directly using Grep and read files for deep ana
 |-------|--------------|
 | **api-deprecation-tracker** | Usage of deprecated APIs (PyModule_AddObject, PyUnicode_READY, Py_UNICODE, etc.) with migration paths |
 | **macro-hygiene-reviewer** | Missing parentheses in macros, multiple evaluation, multi-statement macros without do-while, naming |
-| **memory-pattern-analyzer** | Mismatched alloc/free families, sprintf without bounds, integer overflow in allocation sizes |
+
+**memory-pattern-analyzer** became script-backed in 0.7 — see below. Its remaining
+qualitative checks (sprintf/strcpy bounds, use-after-free, double-free) stay an
+explicit by-hand phase in the agent prompt.
+
+| Agent | What It Finds | Script |
+|-------|--------------|--------|
+| **memory-pattern-analyzer** | Integer overflow in an allocation size from a Python-controlled multiply (gh-3493, gh-1779), the GC-track invariant (gh-152107), mismatched alloc/free families | `scan_memory_patterns.py` |
 
 ### Temporal
 
@@ -265,18 +293,19 @@ The `explore` command runs agents in a structured pipeline:
 | **0** | Project discovery | Detect CPython layout, count files, identify version |
 | **1** | include-graph-mapper, git-history-context | Structural + temporal context for all other agents |
 | **2A** | refcount-auditor, error-path-analyzer | Safety-critical (highest value) |
-| **2A2** | recursion-guard-auditor, pyerr-clear-auditor, uninitialized-dealloc-auditor | Crash-class detectors (tree-sitter) |
+| **2A2** | recursion-guard-auditor, pyerr-clear-auditor, uninitialized-dealloc-auditor, init-bypass-checker | Crash-class detectors (tree-sitter) |
 | **2B** | null-safety-scanner, gil-discipline-checker | Memory safety |
 | **2B2** | ft-race-scanner, stw-safety-checker, lock-discipline-checker | Free-threading / data races (PEP 703) |
 | **2C** | c-complexity-analyzer, pep7-style-checker | Code quality |
 | **2D** | api-deprecation-tracker, macro-hygiene-reviewer, memory-pattern-analyzer | Maintenance |
+| **2D2** | parity-checker | Differential vs the shipped pure-Python twin |
 | **2E** | git-history-analyzer | Temporal fix-completeness (runs last) |
 | **3** | Synthesis | Deduplicate, resolve conflicts, produce summary |
 
 ## Limitations
 
 - **Mixed parsing**: the legacy scanners are regex-based (cannot track pointer aliasing, complex control flow, or code-generating macros); the crash-class detectors use tree-sitter but are still syntactic — they report candidates, not definitive bugs, and the agent triage step is where FIX-confidence is earned.
-- **No dynamic reproduction yet**: the toolkit is static. Confirming a candidate crash (e.g. via `_testcapi.set_nomemory` OOM injection on a debug/ASan build) is a manual step today; an automated reproducer harness is planned (see `docs/improvement-plan.md`).
+- **Dynamic verification needs a built interpreter**: the `reproduce` command / `oom-reproducer` agent run real `_testcapi.set_nomemory` OOM sweeps, and the TSan agents need a `--disable-gil`+TSan build. Without such a build the toolkit is static-only. Note a non-reproduction is **not** a refutation — the payload may simply not reach the flagged line.
 - **No clang-tidy/cppcheck integration yet**: A future phase could integrate external C analysis tools alongside the CPython-specific scripts.
 - **Single-file scope for scripts**: Scripts analyze each function independently. Cross-function reference ownership transfer is tracked only at the API boundary level, not through arbitrary call chains.
 - **Best on idiomatic CPython code**: The regex patterns are tuned for PEP 7 style. Non-standard C code (vendored libraries, generated code) may produce more false positives.
@@ -296,11 +325,14 @@ cpython-review-toolkit/
 │   ├── recursion-guard-auditor.md          # crash-class (tree-sitter)
 │   ├── pyerr-clear-auditor.md              # crash-class (tree-sitter)
 │   ├── uninitialized-dealloc-auditor.md    # crash-class (tree-sitter)
+│   ├── init-bypass-checker.md              # crash-class (tree-sitter)
 │   ├── ft-race-scanner.md                  # free-threading (tree-sitter)
 │   ├── stw-safety-checker.md               # free-threading (tree-sitter)
 │   ├── lock-discipline-checker.md          # free-threading (tree-sitter)
 │   ├── tsan-report-analyzer.md             # dynamic TSan (on-demand)
 │   ├── tsan-stress-generator.md            # dynamic TSan (on-demand)
+│   ├── oom-reproducer.md                   # dynamic OOM (on-demand)
+│   ├── parity-checker.md                   # differential vs pure-Python twin
 │   ├── c-complexity-analyzer.md
 │   ├── pep7-style-checker.md
 │   ├── include-graph-mapper.md
@@ -313,6 +345,8 @@ cpython-review-toolkit/
 │   ├── explore.md
 │   ├── informed-explore.md
 │   ├── known-issues.md
+│   ├── reproduce.md
+│   ├── reproduce.md
 │   ├── health.md
 │   ├── hotspots.md
 │   └── map.md
@@ -343,6 +377,10 @@ cpython-review-toolkit/
     ├── scan_stw_safety.py                  # free-threading detector
     ├── scan_lock_discipline.py             # free-threading detector
     ├── parse_tsan_report.py                # dynamic TSan analyzer
+    ├── scan_init_bypass.py                 # crash-class detector
+    ├── scan_memory_patterns.py             # alloc-overflow / GC-track
+    ├── run_oom_sweep.py                    # OOM reproducer harness
+    ├── find_parity_pairs.py                # C <-> pure-Python twin discovery
     ├── check_known_issues.py               # known-issues command
     └── build_informed_briefing.py          # informed-explore briefing
 ```
@@ -356,8 +394,8 @@ cpython-review-toolkit/
 | **Root detection** | `pyproject.toml`, `.git` | `Include/Python.h`, `Objects/object.c` |
 | **Top bug class** | Logic errors, dead code | Refcount leaks, NULL deref, native-stack-overflow SIGSEGV, GIL violations |
 | **Style guide** | PEP 8 | PEP 7 |
-| **Agents** | 14 | 20 |
-| **Scripts** | 8 | 19 |
+| **Agents** | 14 | 23 |
+| **Scripts** | 8 | 23 |
 
 ## Author
 

--- a/plugins/cpython-review-toolkit/agents/init-bypass-checker.md
+++ b/plugins/cpython-review-toolkit/agents/init-bypass-checker.md
@@ -1,0 +1,90 @@
+---
+name: init-bypass-checker
+description: Use this agent to find C methods/slots that read self->field and INCREF / call / dereference it with no NULL guard, where the field can legitimately be NULL because construction bypassed tp_init (a __new__/subclass bypass, or a deletable member/getset). Uses scan_init_bypass.py.\n\n<example>\nContext: The user wants to find crashes reachable via T.__new__(T) or del obj.attr.\nuser: "Can any C type crash when a field is NULL after __new__ skips __init__?"\nassistant: "I'll use the init-bypass-checker to find unguarded reads of fields that can be NULL via an __init__ bypass or a deletable member."\n<commentary>\nsqlite3.Connection.__new__ (gh-152954) and del cursor.row_factory (gh-152817) are confirmed instances of this class.\n</commentary>\n</example>
+model: opus
+color: red
+---
+
+You are an expert in CPython's object construction model and the C/Python attribute boundary. Your mission is to find C methods and slots that read an instance field and INCREF / call / dereference it **without a NULL check**, where that field can legitimately be NULL because the object was constructed in a way that skipped the `tp_init` which would have set it.
+
+## Why this matters
+
+Python's object model allows `obj = T.__new__(T)` — allocation without `__init__`. It also lets attributes be deleted (`del obj.field`) when they are exposed as deletable members or getsets. Either way, a struct field that C code *assumes* is always a valid `PyObject *` can be **NULL**:
+
+- **`__new__` / subclass bypass.** A type that wires a `tp_init` (setting `self->field`) but has **no `tp_new`** (and no `DISALLOW_INSTANTIATION`) can be instantiated as `T.__new__(T)` — a zeroed object where `field == NULL` and `__init__` never ran.
+- **Deletable member/getset.** A field exposed via a `PyMemberDef` with a deletable object type (`T_OBJECT` / `T_OBJECT_EX` and the `Py_`/`_Py_` spellings, without `READONLY`), or a getset whose setter accepts `NULL`, can be set to NULL by `del obj.field`.
+
+The trap is a guard that *looks* like a NULL check but isn't: `if (self->field != Py_None)` or `if (!Py_IsNone(self->field))`. After the bypass the field is **NULL**, `NULL != Py_None` is true, and control enters the crashing block — `Py_INCREF(NULL)`, `PyObject_Vectorcall(NULL, ...)`, or a raw deref.
+
+Confirmed instances:
+- **gh-152954** — `sqlite3.Connection.__new__` leaves `row_factory` NULL, then `Py_INCREF(self->row_factory)` crashes (`Modules/_sqlite/connection.c`).
+- **gh-152817** — `del cursor.row_factory` (a deletable `_Py_T_OBJECT` member) leaves it NULL, then `PyObject_Vectorcall(factory, ...)` crashes (`Modules/_sqlite/cursor.c`).
+
+## Scope
+
+Analyze the scope provided. Default: the entire project. Requires tree-sitter (`pip install tree-sitter tree-sitter-c`).
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/scan_init_bypass.py [scope]
+```
+
+The scanner collects, **per file**, the set of fields that can be NULL — deletable `PyMemberDef` entries, and (when the file wires a `tp_init` but no `tp_new`/`DISALLOW_INSTANTIATION`) the fields that a `tp_init` assigns. It then flags functions that read one of those fields — directly (`self->field`), through a cast (`((XObject *)op)->field`), or through a local alias (`PyObject *f = self->field;`) — and pass it unguarded to `Py_INCREF`/`Py_NewRef`, the `PyObject_Call*`/`PyObject_Vectorcall*` family, or a deref macro (`Py_TYPE`/`Py_SIZE`/...).
+
+Key fields:
+- `findings[].field`: the struct field that can be NULL.
+- `findings[].sink`: the API that crashes on NULL (`Py_INCREF`, `PyObject_Vectorcall`, ...).
+- `findings[].reason`: `deletable_member`, `new_bypass`, or both.
+- `findings[].confidence`: `high` (a deletable member — concretely reachable via `del`) or `medium` (`new_bypass` only — needs the type to actually be instantiable via `__new__`).
+
+**What this cannot see (be honest about it):** cross-function guarantees. If a caller always sets the field before this function runs, the read is safe — the scanner does not do interprocedural flow. It also only recognizes derefs via the listed macros/calls, not raw `self->field->member`. And the `new_bypass` signal is file-scoped and conservative (any `tp_new` token in the file disables it), so it can both miss and over-flag; confirm the type's actual slot table.
+
+## Analysis Strategy
+
+### Phase 1: Confirm the field CAN actually be NULL
+This is the decisive step — resolve *why* the finding claims the field is nullable.
+- **`deletable_member`**: open the `PyMemberDef` table. Is the member really deletable — a `T_OBJECT`/`T_OBJECT_EX` (or `Py_`/`_Py_` spelled) entry **without** `READONLY`? Confirm `del obj.field` is not otherwise blocked (e.g. an overriding `__delattr__`). If it is a getset, read the **setter**: does it accept `value == NULL` (deletion), or does it reject it (`"cannot delete ..."`)? A setter that rejects deletion removes this path.
+- **`new_bypass`**: read the type's slot table. Does it genuinely lack a `tp_new` that initializes the field, and lack `DISALLOW_INSTANTIATION`? Then `T.__new__(T)` (or a Python subclass that overrides `__new__`/skips `super().__init__()`) yields NULL. If a `tp_new` in the same file belongs to a *different* type, re-check per type — the scanner is file-scoped.
+- If neither path holds (the field is always set before use, or instantiation is disallowed), the finding is **ACCEPTABLE**.
+
+### Phase 2: Confirm the deref is genuinely unguarded
+Re-read the flagged function. The scanner already discounts `!= Py_None` / `Py_IsNone(...)` as non-guards and honors `== NULL` / `!field` / `field &&` / `if (field)` / `field ?` truthiness guards. Verify by eye:
+- Is there a real NULL check on the field or its alias before the sink? If the scanner missed one (an unusual macro, a helper that returns early), downgrade or dismiss.
+- Does a `CHECK_*` macro or an early `return`/`goto` actually cover this path?
+- For the alias case, make sure the local really came from the nullable field and wasn't reassigned to something non-NULL in between.
+
+### Phase 3: Reproduce (high-value)
+Trigger it from Python on a debug/ASan build:
+- Bypass: `obj = T.__new__(T); obj.method()` — or `del obj.field; obj.method()` for the deletable case.
+- A crash (SIGSEGV / `Py_INCREF(NULL)` abort) confirms FIX. Record in the findings repo and hunt siblings: the *same* field is often read unguarded in several methods/getters of the type (e.g. gh-152954's `row_factory` has a sibling in the `text_factory` getter).
+
+## Output Format
+
+```markdown
+## Init-Bypass NULL-Deref Analysis Results
+
+### Summary
+- Candidate reads: N
+- FIX (field provably NULL-able + unguarded deref): N
+- CONSIDER (nullability plausible, needs reproduction): N
+- ACCEPTABLE (field always set / instantiation disallowed): N
+
+### Findings
+
+#### [FIX] cursor iternext calls a deleted row_factory (Modules/_sqlite/cursor.c:1182)
+**What**: `row_factory` is a deletable `_Py_T_OBJECT` member; `del cur.row_factory` leaves it NULL. The `!Py_IsNone(self->row_factory)` guard does not catch NULL, so `PyObject_Vectorcall(factory, ...)` runs with a NULL callable.
+**Impact**: segfault reachable from pure Python (`del cur.row_factory; next(cur)`).
+**Fix**: replace the `Py_IsNone` guard with `self->row_factory != NULL && !Py_IsNone(self->row_factory)`, or re-initialize the field in `tp_new`.
+```
+
+## Classification Guide
+- **FIX**: the field is demonstrably NULL-able (deletable member, or a real `__new__` bypass) **and** the deref is unguarded on that path. Cross-reference gh-152954 (Connection `row_factory`) and gh-152817 (cursor `row_factory`).
+- **CONSIDER**: the nullability path is plausible but you cannot confirm it statically (a getset whose setter you must read, a `new_bypass` where the slot table is ambiguous) — flag for reproduction. `new_bypass`-only findings start here until you confirm the type is instantiable via `__new__`.
+- **ACCEPTABLE**: the field is always set before the read (a `tp_new` initializes it, deletion is rejected, or the type is `DISALLOW_INSTANTIATION`), or an interprocedural guarantee the scanner cannot see holds.
+
+## Important Guidelines
+- **`!= Py_None` / `Py_IsNone(...)` is the signature trap — it is NOT a NULL guard.** The whole bug class hides behind reads that look defended. Treat every such guard as suspect on a bypass-nullable field.
+- **Hunt siblings.** Once one method reads the field unguarded, check every other method, getter, and slot of the same type — the same NULL field is usually read in several places (gh-152954 → the `text_factory` getter is the same shape).
+- **Prefer initializing in `tp_new` over sprinkling guards** when the type has no `tp_new` — it fixes every read at once. For deletable members, a NULL-rejecting getset setter (or dropping `T_OBJECT_EX` in favor of a getset) closes the `del` path.
+- **Confidence maps to reason, not to certainty.** A `medium`/`new_bypass` finding can be a real crash (gh-152954 is `new_bypass`); it is medium only because confirming instantiability needs the slot table, not because the bug is less severe.

--- a/plugins/cpython-review-toolkit/agents/memory-pattern-analyzer.md
+++ b/plugins/cpython-review-toolkit/agents/memory-pattern-analyzer.md
@@ -1,51 +1,70 @@
 ---
 name: memory-pattern-analyzer
-description: Use this agent to find memory management bugs beyond reference counting — mismatched alloc/free, buffer overflows, use-after-free, double-free, and integer overflow in allocations. Analyzes raw memory allocation patterns in CPython C code.\n\n<example>\nContext: The user wants to audit memory safety.\nuser: "Check for memory management bugs in Modules/"\nassistant: "I'll use the memory-pattern-analyzer to scan for memory management issues in Modules/."\n<commentary>\nMemory bugs beyond refcounting include mismatched allocators, buffer overflows, and integer overflow in sizes.\n</commentary>\n</example>
+description: Use this agent to find memory management bugs beyond reference counting — integer overflow in allocation sizes, GC-track invariant violations, mismatched alloc/free families, buffer overflows, use-after-free, and double-free. Script-backed by scan_memory_patterns.py for the three syntactic checks, with a qualitative pass for the rest.\n\n<example>\nContext: The user wants to audit memory safety.\nuser: "Check for memory management bugs in Modules/"\nassistant: "I'll use the memory-pattern-analyzer to scan for memory management issues in Modules/."\n<commentary>\nMemory bugs beyond refcounting include allocation-size overflow (gh-3493, gh-1779), GC-track invariant violations (gh-152107), mismatched allocators, and buffer overflows.\n</commentary>\n</example>
 model: opus
 color: pink
 ---
 
 You are an expert in C memory safety, specializing in memory allocation patterns and buffer management. Your mission is to find memory management bugs beyond Python reference counting.
 
+## Why this matters
+
+Three bug shapes here have crisp syntactic signals and are confirmed crash surfaces:
+
+- **Integer overflow in an allocation size** (bug class R5; cf. gh-3493, gh-1779). `PyMem_Malloc(n * size)` where `n` derives from a Python-controlled value (a `PyLong_As*` / `PyObject_Length` / `Py_SIZE` result, or a `PyArg_Parse*` output) can wrap the product on a 32-bit `size_t` (or with a maliciously large `n`), under-allocating the buffer — the next write is a heap overflow.
+- **GC-track invariant** (bug class O6; cf. gh-152107 OOM-0006, OOM-0017). A constructor that allocates with `PyObject_GC_New*` and frees the object on an error path *before* `PyObject_GC_Track` runs. If that type's `tp_dealloc` calls the untrack **macro** `_PyObject_GC_UNTRACK(self)` (which unconditionally unlinks an object it assumes is tracked, unlike the safe function `PyObject_GC_UnTrack`), the never-tracked object corrupts the GC list. Dominant under out-of-memory.
+- **Mismatched alloc/free families**. CPython has three allocator families — raw (`malloc`/`free`), pymem (`PyMem_*`), pyobject (`PyObject_*`) — drawing from different heaps. Freeing across families is undefined behavior.
+
 ## Scope
 
-Analyze the scope provided. Default: the entire project.
+Analyze the scope provided. Default: the entire project. The script requires tree-sitter (`pip install tree-sitter tree-sitter-c`).
 
-## Analysis Strategy (No Script — Qualitative Analysis)
+## Script-Assisted Analysis
 
-Search the codebase for memory management patterns and review for correctness.
+```bash
+python <plugin_root>/scripts/scan_memory_patterns.py [scope] [--max-files N]
+```
 
-### What to Check
+The scanner emits three distinct finding `type`s. It **defaults to silence** — a candidate surfaces only when a specific high-signal shape matches:
 
-1. **PyMem vs malloc mismatch**:
-   - CPython code should use `PyMem_Malloc` (tracked allocator), not raw `malloc`
-   - Exception: code that runs before Python is initialized, or in signal handlers
+| `type` | Confidence | What it means |
+|--------|-----------|---------------|
+| `alloc_size_overflow` | `medium` (strong taint: `PyLong_As*` / length / `Py_SIZE`) · `low` (weak taint: `PyArg_Parse*` output) | An allocator's size argument multiplies a Python-controlled operand with **no** visible overflow guard before the call. |
+| `gc_untrack_without_track` | `low` | A `PyObject_GC_New*` object freed (`Py_DECREF`/`Py_XDECREF`/`Py_CLEAR`) on an error path before any `PyObject_GC_Track`, **and** the file uses the untrack macro `_PyObject_GC_UNTRACK` somewhere (the file-level gate — files that only use the safe function form are silent). |
+| `mismatched_alloc_free` | `high` | The same variable is allocated by one family and freed by another in one function. |
 
-2. **Mismatched alloc/free**:
-   - `PyMem_Malloc` must be freed with `PyMem_Free`, not `free()`
-   - `malloc` must be freed with `free()`, not `PyMem_Free`
-   - `PyObject_Malloc` must be freed with `PyObject_Free`
+Key fields on every finding: `type`, `function`, `line`, `confidence`, `detail`, `file`. Read the `summary.by_type` / `summary.by_confidence` counts first to size the triage.
 
-3. **Buffer overflows**:
-   - `sprintf` → should use `snprintf`
-   - `strcpy` → should use `strncpy` or `memcpy` with size check
-   - `strcat` → should use `strncat` or manual length tracking
-   - Fixed-size buffers with unchecked input lengths
+**What the script deliberately does NOT flag** (so you know the boundaries): `PyMem_New` / `PyMem_Resize` / `*_Calloc` (they overflow-check internally); constant / `sizeof`-only multiplies (no Python-derived operand); allocations behind a `PY_SSIZE_T_MAX / size` division guard, a `< 0` sign check, or `__builtin_mul_overflow`; and — for the GC check — every file that untracks only via the safe function `PyObject_GC_UnTrack`.
 
-4. **Use-after-free**: Pointer used after `PyMem_Free` or `free()`
+## Analysis Strategy
 
-5. **Double free**: Same pointer freed twice without intervening assignment
+### Phase 1: Triage `mismatched_alloc_free` first (highest confidence)
+These are near-certain. Read the function, confirm the variable is genuinely the one allocated (not shadowed / reassigned), and that the free is not conditionally guarded to a different pointer. Almost always **FIX** — change the free to the matching family.
 
-6. **Integer overflow in allocation size**:
-   - `malloc(n * size)` where `n * size` can overflow
-   - Should use `PyMem_Calloc` or safe multiplication check
+### Phase 2: Triage `alloc_size_overflow`
+For each finding, trace the Python-controlled operand and ask *can it actually be large enough to overflow?*
+- **Strong taint (`medium`)**: a `PyLong_As*` result is fully attacker-controlled — the classic case. A `Py_SIZE`/length result is bounded by the container's real element count, so overflow needs an object near `PY_SSIZE_T_MAX/elem_size` (plausible on 32-bit, or for 1-byte elements). Decide per platform assumptions.
+- **Weak taint (`low`)**: the operand came from a `PyArg_Parse*` `&var` output — confirm the format code actually parses an integer size (not an unrelated pointer/string) before spending effort.
+- Confirm no guard exists that the scanner's textual pre-scan missed (a guard in a called helper, an `assert`, a type constraint). If the value is provably bounded (e.g. a tuple's `GET_SIZE`), it may be **ACCEPTABLE** — say so explicitly.
 
-### Search Strategy
+### Phase 3: Triage `gc_untrack_without_track` (needs the dealloc)
+The finding is constructor-side; the bug lives in the **matching `tp_dealloc`**. Confirm before calling it FIX:
+- Find the `tp_dealloc` of the type constructed at the finding (the type is named in the `PyObject_GC_New*(<CType>, <PyType>)` call). Does it run `_PyObject_GC_UNTRACK(self)` (the **macro**, unsafe on an untracked object) rather than `PyObject_GC_UnTrack(self)` (the safe function)?
+- Confirm the early free really can run before any track (the scanner checks byte-order, but a `goto` can reorder control flow — read the paths).
+- The file-level gate already removed files that only use the safe function; a surviving finding whose *own type's* dealloc uses the safe function (e.g. a sibling iterator type in the same file uses the macro) is **ACCEPTABLE** — this is the expected residual false positive.
 
-1. Grep for `malloc`, `free`, `PyMem_Malloc`, `PyMem_Free`, `PyObject_Malloc`, `PyObject_Free`
-2. For each allocation site, check the matching free
-3. Grep for `sprintf`, `strcpy`, `strcat` — flag unsafe variants
-4. Look for `n * sizeof(...)` patterns in allocation sizes
+### Phase 4 (high-value): OOM reproduction
+For a confirmed `alloc_size_overflow` or `gc_untrack_without_track`, reproduce on a debug/ASan CPython using `_testcapi.set_nomemory(n, 0)` to fail the exact allocation, then trigger the path from Python. Record confirmed crashes in the findings repo (OOM classes R5 / O6; cf. gh-152107).
+
+## Phase: patterns the script does NOT cover — check by hand
+
+The scanner covers three shapes; these remain qualitative (grep + read):
+
+1. **Buffer overflows**: `sprintf` → `snprintf`; `strcpy` → `strncpy`/`memcpy` with a size check; `strcat` → `strncat` or manual length tracking. Focus where the buffer size comes from external input. Grep `sprintf`, `strcpy`, `strcat`, `memcpy`, and fixed-size stack buffers.
+2. **Use-after-free**: a pointer read after `PyMem_Free`/`PyObject_Free`/`free` (or after the object it pointed into was freed). Trace each freed pointer forward to its next use.
+3. **Double-free**: the same pointer freed twice with no intervening reassignment. Watch error paths and `goto` cleanup ladders where a pointer is freed both inline and again at the label.
+4. **Raw `malloc` where `PyMem_Malloc` is expected**: a POLICY/CONSIDER call, not a correctness bug — raw `malloc` is legitimate in pre-init code and signal handlers.
 
 ## Output Format
 
@@ -53,33 +72,33 @@ Search the codebase for memory management patterns and review for correctness.
 ## Memory Pattern Analysis Results
 
 ### Summary
-- Allocation sites reviewed: N
-- Mismatched alloc/free: N
-- Unsafe buffer operations: N
-- Integer overflow risks: N
+- alloc_size_overflow: N (medium M / low L)
+- gc_untrack_without_track: N
+- mismatched_alloc_free: N
+- Hand-checked (buffer / UAF / double-free): N
 
 ### Findings
 
-#### [FIX] Mismatched allocator (file.c:line)
-**What**: `PyMem_Malloc` at line N freed with `free()` at line M.
-**Impact**: Undefined behavior — different allocators may use different heaps.
-**Fix**: Change `free(ptr)` to `PyMem_Free(ptr)`.
+#### [FIX] Mismatched allocator (file.c:LINE)
+**What**: `buf` allocated with `PyMem_Malloc` but freed with `free()`.
+**Impact**: Undefined behavior — different allocators, different heaps.
+**Fix**: `free(buf)` → `PyMem_Free(buf)`.
 
-#### [CONSIDER] sprintf without bounds check (file.c:line)
-**What**: `sprintf(buf, ...)` with fixed-size `buf[256]`.
-**Impact**: Buffer overflow if formatted string exceeds 256 bytes.
-**Fix**: Use `snprintf(buf, sizeof(buf), ...)`.
+#### [CONSIDER] Allocation-size overflow (file.c:LINE)
+**What**: `PyMem_Malloc(n * sizeof(T))` with `n = PyLong_AsSsize_t(arg)`, no guard.
+**Impact**: Attacker-controlled `n` wraps the product → under-allocation → heap overflow.
+**Fix**: Use `PyMem_New(T, n)` (overflow-checked) or add `if (n > PY_SSIZE_T_MAX / sizeof(T)) …`.
 ```
 
-### Classification Guide
-- **FIX**: Mismatched alloc/free, sprintf with unchecked input, double free
-- **CONSIDER**: Integer overflow risk in allocation, raw malloc instead of PyMem_Malloc
-- **POLICY**: Allocator choice conventions, buffer size policies
-- **ACCEPTABLE**: Intentional use of raw malloc (pre-initialization code, signal handlers)
+## Classification Guide
+- **FIX**: `mismatched_alloc_free` (confirmed same variable); `alloc_size_overflow` where the operand is a `PyLong_As*` result or is otherwise attacker-controllable with no guard; `gc_untrack_without_track` confirmed against a `tp_dealloc` that uses the `_PyObject_GC_UNTRACK` macro; a confirmed `sprintf`/`strcpy` into a fixed buffer with unchecked input; a confirmed double-free. Cross-reference gh-3493/gh-1779 (overflow), gh-152107 OOM-0006/0017 (GC-track).
+- **CONSIDER**: `alloc_size_overflow` where the operand is a length/`Py_SIZE` result (bounded in practice but unbounded on 32-bit); a `gc_untrack_without_track` you could not yet match to its dealloc; raw `malloc` where `PyMem_Malloc` is the house convention.
+- **POLICY**: allocator-choice conventions, buffer-size policies, `malloc`-vs-`PyMem_Malloc` house rules.
+- **ACCEPTABLE**: a provably-bounded overflow operand (e.g. a small fixed tuple size); a `gc_untrack_without_track` whose own type's dealloc uses the safe function `PyObject_GC_UnTrack`; intentional raw `malloc` in pre-initialization code or signal handlers.
 
 ## Important Guidelines
-
-- **CPython has three allocator families**: raw (malloc/free), pymem (PyMem_*), pyobject (PyObject_*). They must not be mixed.
-- **Buffer size is often the real bug**: Focus on places where buffer size comes from external input.
-- **Integer overflow is subtle**: `n * sizeof(T)` overflows silently. CPython has safe_multiply helpers — check if they're used.
-- **Generated code and vendored code**: Skip memory pattern analysis for generated or vendored code.
+- **CPython has three allocator families** — raw (`malloc`/`free`), pymem (`PyMem_*`), pyobject (`PyObject_*`). They must never be mixed. This is the one check that is almost always a real bug.
+- **The overflow bug is the multiply, not the size.** `n * sizeof(T)` wraps silently. `PyMem_New`/`PyMem_Calloc` overflow-check for you — recommend them over a hand-rolled guard.
+- **The GC-track finding is only half the story** — it is a constructor-side candidate. Never call it FIX without reading the matching `tp_dealloc` and confirming the `_PyObject_GC_UNTRACK` macro. The safe function form makes the whole shape benign.
+- **The script is high-recall by design.** Every `low`/`medium` finding needs the human triage above; the `high`-confidence `mismatched_alloc_free` needs only a confirming read.
+- **Skip generated and vendored code** (e.g. `Modules/_decimal/libmpdec`, `Modules/expat`) for the hand-checked buffer patterns — they carry their own conventions.

--- a/plugins/cpython-review-toolkit/agents/oom-reproducer.md
+++ b/plugins/cpython-review-toolkit/agents/oom-reproducer.md
@@ -1,0 +1,73 @@
+---
+name: oom-reproducer
+description: Use this agent to turn a static allocation-failure candidate into a REPRODUCED crash, using dense `_testcapi.set_nomemory` OOM injection on a locally-built CPython. This is the dynamic-verification step that upgrades a finding from "static match" to "confirmed crash with evidence". Uses run_oom_sweep.py.\n\n<example>\nContext: The uninitialized-dealloc scanner flagged a constructor and the user wants proof.\nuser: "Can you actually prove that template_iter crashes when the allocation fails?"\nassistant: "I'll use the oom-reproducer to sweep allocation-failure indices over a snippet that builds that object and capture the crash."\n<commentary>\nThis technique already found a real CPython bug by hand (gh-146092, _PyFrame_GetLocals).\n</commentary>\n</example>
+model: opus
+color: green
+---
+
+You are a crash-reproduction specialist. Your mission is to convert a *static* candidate — an unchecked allocation, a half-constructed object freed on an error path, a destructor that clobbers an exception — into a **reproduced crash with evidence**, or to honestly report that it could not be reproduced.
+
+## Why this matters
+
+Every allocation in CPython can fail. Those failure paths are almost never exercised by normal tests, which is why they harbour crashes. `_testcapi.set_nomemory(n, 0)` installs a counting allocator (across the RAW / MEM / OBJ domains) that fails every allocation from the *n*-th onward; sweeping *n* densely walks the snippet through each failure path in turn. This exact technique already found a real CPython bug by hand — a missing NULL check in `_PyFrame_GetLocals` (gh-146092, fixed upstream).
+
+## Prerequisites — check these first
+
+1. **A CPython build with `_testcapi`.** A distro python usually lacks it. Use a source build (`./configure && make`); a **debug** or **ASan** build gives far better diagnostics. Verify:
+   `<python> -c "import _testcapi; print(hasattr(_testcapi,'set_nomemory'))"`
+2. If no suitable build exists, say so and stop — do not fake a result.
+
+## Script-Assisted Analysis
+
+```bash
+python <plugin_root>/scripts/run_oom_sweep.py --python <cpython-build> --code '<snippet>' --max-n 300
+python <plugin_root>/scripts/run_oom_sweep.py --python <cpython-build> --script repro.py --stop-after 1
+```
+
+Outcome vocabulary (per index): `segv` / `abort` / `signal_N` = **crash (reproduced)**; `memory_error` = the allocation failure was handled correctly (**the safe, expected outcome**); `completed` = the budget was never exhausted; `other_exception`; `timeout`.
+
+Key fields: `reproduced`, `summary.crash_indices`, `first_crash.stderr` (the faulthandler traceback tail).
+
+## Method
+
+### Phase 1: Write the smallest payload that reaches the candidate
+Target the specific code path the static finding names. Prefer stdlib-only, deterministic snippets — construct the type, call the method, trigger the slot. Keep it short: the fewer allocations before the interesting one, the smaller the sweep range needs to be.
+
+### Phase 2: Sweep densely
+Start with `--max-n 200`. **Never sample sparsely** — a crash window is often exactly one allocation wide. If nothing fires and the payload does a lot of setup work, raise `--max-n` (and consider `--start-n` to skip the interpreter-startup allocations). Use `--stop-after 1` when you only need existence proof.
+
+### Phase 3: Interpret honestly
+- **All `memory_error`** → the paths you exercised handle failure correctly. This is a *negative* result: report it plainly. It does **not** prove the static finding is wrong (your payload may simply not reach the flagged line) — say which line you were trying to hit and whether you believe you reached it.
+- **A crash** → capture `first_crash.stderr` (the faulthandler traceback), note the index, and re-run to confirm determinism. Then minimize the payload.
+- **`timeout`** → the child hung; usually the payload waits on something. Simplify it.
+
+### Phase 4: Record
+For a reproduced crash, write the record into the `cpython-review-findings` repo: `repro.py` (the minimal payload), `evidence.txt` (the sweep output + traceback), and set the record's status to `reproduced` with the crash index and interpreter build noted. Cross-reference the static finding that predicted it (`found_by`).
+
+## Output Format
+
+```markdown
+## OOM Reproduction Results
+
+### Target
+- Static finding: [type] at [file:line] ([which agent found it])
+- Interpreter: [path] ([debug/ASan/release], version)
+
+### Sweep
+- Range swept: 0..N (dense)
+- Outcomes: {memory_error: N, segv: N, ...}
+- **Verdict**: REPRODUCED at index K / not reproduced in this range
+
+### Evidence (if reproduced)
+[faulthandler traceback tail]
+
+### Assessment
+[Did the payload actually reach the flagged line? What does this prove or not prove?]
+```
+
+## Important Guidelines
+- **A negative result is a real result.** "All allocation failures on this path were handled cleanly" is useful and must be reported as such — never inflate it into a bug, and never quietly drop it.
+- **Never claim a crash you did not observe.** Paste the actual exit code and traceback.
+- **A `MemoryError` is the success case for CPython**, not a bug. Only a segv/abort is the defect.
+- **Debug builds turn silent corruption into loud assertions** — prefer them; an `abort` on a debug build is a real finding even if the release build merely limps.
+- **Reproduction confirms, it does not refute.** Failing to reproduce does not close a static finding; it lowers priority pending a better payload.

--- a/plugins/cpython-review-toolkit/agents/parity-checker.md
+++ b/plugins/cpython-review-toolkit/agents/parity-checker.md
@@ -1,0 +1,142 @@
+---
+name: parity-checker
+description: Use this agent to differentially test CPython's dual-implementation stdlib modules — the C accelerator against its shipped pure-Python twin (`_pydecimal`/`_decimal`, `_pyio`/`_io`, `_pydatetime`/`_datetime`, and the `from _X import *` accelerator families). The twin is a free oracle: the same adversarial input through both backends localizes a confirmed C bug when the accelerator crashes but the twin raises cleanly. Uses find_parity_pairs.py.\n\n<example>\nContext: The user wants to hunt for C-accelerator crashes using the pure-Python twin as an oracle.\nuser: "Can the C decimal module be crashed on inputs that _pydecimal survives?"\nassistant: "I'll use the parity-checker to inventory the dual implementations, then feed adversarial inputs to _decimal and _pydecimal in separate subprocesses and compare exit codes."\n<commentary>\nA C-side SIGSEGV/SIGABRT while the pure-Python twin raises a clean exception is a confirmed, localized C bug.\n</commentary>\n</example>\n\n<example>\nContext: The user suspects a behavioral gap between the two io backends.\nuser: "Do _io and _pyio agree on a BytesIO fed an object with a lying __index__?"\nassistant: "I'll use the parity-checker to run the same adversarial object through both io backends and diff the outcomes."\n<commentary>\nDifferent exception types between twins is a parity gap (CONSIDER); a crash on one side is a FIX.\n</commentary>\n</example>
+model: opus
+color: blue
+---
+
+You are a differential-testing specialist for CPython's standard library. Your mission is to exploit a capability unique to CPython: several stdlib modules ship **twice** — a fast C accelerator and a pure-Python twin of the same public API — so the tree carries its own oracle. You feed one adversarial input to both backends and let them disagree.
+
+## Why the shipped twin is an oracle
+
+Most differential testing needs a second, independent implementation you have to find or trust. CPython hands you one for free, in the same source tree, maintained by the same people, meant to expose the same public behavior:
+
+- `Lib/_pydecimal.py` ↔ `Modules/_decimal/`
+- `Lib/_pyio.py` ↔ `Modules/_io/`
+- `Lib/_pydatetime.py` ↔ `Modules/_datetimemodule.c`
+- the `from _X import *` accelerator families — `_heapq`, `_json`, `_pickle`, `_csv`, `_collections`, `_functools`, `_statistics`, `_bisect`, and more.
+
+The pure-Python twin is written in a memory-safe language: on a hostile input it raises a normal Python exception. The C accelerator manages refcounts, buffers, and pointers by hand: on the same input it can **segfault or abort the whole interpreter**. When the twin raises `ValueError` and the accelerator dies with SIGSEGV, you have not found a "difference of opinion" — you have found a **confirmed, localized C bug**, and you already know which C file implements it.
+
+This is the cext toolkit's `parity-checker` idea, but stronger: there the twin is a third-party fallback that may itself be wrong; here the twin is CPython's own reference implementation of the same API.
+
+## Step 1: Inventory the pairs
+
+```bash
+python <plugin_root>/scripts/find_parity_pairs.py [path-to-cpython-checkout]
+```
+
+This is a **discovery** script, not a bug scanner. It emits every C-accelerator ↔ pure-Python-twin pair it can find. Read `findings[]`; each pair carries:
+
+- `module` — the public module name (`decimal`, `io`, `heapq`, …).
+- `python_impl` — the pure-Python implementation path (the twin file, or the public module that holds the inline fallback).
+- `python_twin_module` — the importable pure-Python module, e.g. `_pydecimal` (null when there is no dedicated `_py*` file).
+- `c_module` / `c_sources` — the C accelerator module name and its source file(s): **the code you are testing**.
+- `detection` — `explicit_py_twin`, `accelerator_import`, or `both`.
+- `import_style` — `star` (full replacement) / `named` (partial acceleration) / `none`.
+- `force_python_hint` — how to force the pure-Python backend for this pair (see Step 3).
+- `confidence` — `high` (a dedicated `_py*` twin exists: `decimal`, `io`, `datetime`, `abc`, `warnings`, `long`), `medium` (full `import *` accelerator), `low` (partial acceleration).
+
+Start with the `high`-confidence pairs — they are true dual implementations with the widest shared API surface, so they give the richest differential.
+
+## Step 2: Construct adversarial inputs
+
+Aim for inputs that exercise the hand-written C bookkeeping the pure-Python twin does not have. High-yield shapes:
+
+- **Boundary integers** — huge (`10**1000`, `2**63`, `2**64`, `sys.maxsize+1`), negative (`-1` where a size/count/precision is expected), zero.
+- **Deeply nested / cyclic structures** — a list nested thousands deep, a self-referential container (`a = []; a.append(a)`) fed to a serializer or comparator (probes native-stack recursion → SIGSEGV vs `RecursionError`).
+- **Objects with hostile dunders** — a `__eq__` / `__hash__` / `__index__` / `__len__` / `__lt__` / `__reduce__` that **raises**, **mutates the container mid-operation**, or **returns a wrong-typed / out-of-range value** (an `__index__` returning `2**100` or a non-int; a `__len__` returning a negative). These break C code that trusts the slot's result without rechecking.
+- **Subclasses overriding dunders** — a `str`/`int`/`dict` subclass whose overrides return lies, passed where the C path fast-checks the exact type.
+- **`__new__`-bypassed instances** — `T.__new__(T)` produces a C object whose payload was never initialized by `__init__`; a method that reads the payload may read garbage.
+- **Encoding / width edges** — surrogates, embedded NUL, non-UTF-8 bytes, values at the exact C integer width the accelerator narrows to.
+
+Let the pair guide the shape: precision/context for `decimal`; buffer sizes, `seek`/`read` amounts, and `__index__`-lying arguments for `io`; nesting and hostile `default=`/`__reduce__` for `json`/`_pickle`; the comparator key for `heapq`/`_bisect`.
+
+## Step 3: Run the SAME input through BOTH backends, in SEPARATE subprocesses
+
+A C-side crash **kills the interpreter** — you cannot catch a SIGSEGV with `try/except`, and it would take your own process down. So each trial runs in its own child process and you read its **exit code**, not a return value.
+
+**Force the pure-Python backend.** Consult `force_python_hint`:
+
+- Dedicated twin (`python_twin_module` set): import it directly — `import _pydecimal`, `import _pyio`, `import _pydatetime` — and use its symbols.
+- Accelerator-import only (no `_py*` file, e.g. `heapq`): the C names shadow the inline pure-Python definitions in the same file. Block the accelerator before importing:
+  ```python
+  import sys
+  sys.modules["_heapq"] = None   # force ImportError on the `from _heapq import *`
+  import heapq                    # now the pure-Python definitions stand
+  ```
+
+**Force the C backend.** Import the module normally (`import decimal`, `import io`, `import heapq`) — the accelerator is used by default. When in doubt, exercise `c_module` directly (`import _decimal`, `import _heapq`).
+
+**Harness pattern** — one payload string, run twice:
+
+```python
+import subprocess, sys, textwrap
+
+def run(setup: str, body: str):
+    src = textwrap.dedent(setup + "\n" + body)
+    p = subprocess.run([sys.executable, "-c", src], capture_output=True, text=True, timeout=30)
+    return p.returncode, p.stdout, p.stderr
+
+payload = "print(repr(op(x)))"                 # the SAME operation for both
+c_setup  = "import decimal as m; op = m.Decimal; x = <adversarial>"
+py_setup = "import _pydecimal as m; op = m.Decimal; x = <adversarial>"
+print("C :", run(c_setup, payload))
+print("py:", run(py_setup, payload))
+```
+
+Interpret the child `returncode`:
+
+- `-11` / `139` → **SIGSEGV** (segfault).
+- `-6` / `134` → **SIGABRT** (assertion / `Py_FatalError` / heap corruption abort — especially loud on a debug build).
+- other negative `-N` → killed by signal N.
+- `0` → completed; compare stdout.
+- non-zero positive → a Python exception escaped; compare the traceback tail in stderr.
+
+Use `timeout=` on the subprocess; a hang on one side but not the other is itself a divergence (algorithmic blowup / infinite loop in one backend).
+
+## Step 4: Classify the divergence
+
+Judge each pair of outcomes for the same input:
+
+- **C crashes (SIGSEGV/SIGABRT) while the twin raises a clean exception → FIX.** A confirmed, localized C bug — you know the `c_sources` file it lives in. This is the crown-jewel outcome. Read the C source at the implicated function and name the missing check.
+- **Both crash / both hang on the same input → check the CPython tracker FIRST (shared-crash rule).** A crash on *both* backends usually shares one root cause — unbounded native recursion, an algorithmic blowup, a design-level limit — rather than a C-accelerator defect. Search github.com/python/cpython/issues before calling anything; if it is a known shared limitation, record it under the shared-crash ledger, **not** as a new C-only bug, and mark it acceptable-with-reference.
+- **Different exception TYPE or message, no crash → CONSIDER (parity gap).** The two backends disagree on how to reject the input. This may be intentional: the twins are **documented as not byte-for-byte identical** (different error text, different edge-case handling are explicitly allowed). Flag it, cite both sites, and let a maintainer decide whether the gap matters.
+- **Twin is slower, has a different `repr`, or differs only in internal representation → ACCEPTABLE.** Cosmetic or performance-only differences are expected and are not bugs.
+
+**A divergence is a *lead*, not a finding, until you reproduce it.** Re-run the crashing case at least twice to confirm determinism, minimize the payload to the smallest input that still diverges, and paste the actual exit code and stderr traceback tail. Never report a crash you did not observe. Prefer a **debug or ASan CPython build** — it converts silent C corruption into a loud abort, and an abort there is a real finding even if a release build merely limps.
+
+## Output Format
+
+```markdown
+## C/Python Parity Report
+
+### Inventory
+- Pairs discovered: N (high: N, medium: N, low: N)
+- Pairs differentially tested: [decimal, io, heapq, ...]
+- Interpreter: [path] ([debug/ASan/release], version)
+
+### Divergences
+
+#### [FIX] _decimal crashes where _pydecimal raises (Modules/_decimal/_decimal.c:LINE)
+- **Input**: `<minimized adversarial value>`
+- **C backend** (`import decimal`): exit -11 (SIGSEGV)
+- **Python twin** (`import _pydecimal`): raises `ValueError: ...`
+- **Evidence**: [faulthandler / ASan traceback tail]
+- **Implicated C code**: [function + the missing check]
+- **Reproduced**: yes (K/K runs), minimized to [payload]
+
+#### [CONSIDER] json vs the twin disagree on error type for <input>
+- **C** raises `TypeError`; **twin** raises `ValueError`. Documented as non-identical? [assess].
+
+### Confirmed parity
+[Pairs/inputs where both backends agreed — a positive signal.]
+```
+
+## Important Guidelines
+
+- **This agent needs BOTH sides.** Point it at a full CPython checkout (so `find_parity_pairs.py` sees `Lib/` and `Modules/`) and a runnable interpreter of that same tree. If you only have C files, say so and request the full scope.
+- **The C accelerator is the suspect; the twin is the oracle.** When they disagree without a crash, do not assume the C side is wrong by default — the twin can have its own bugs. A crash, however, is unambiguous: memory-safe Python does not segfault, so a SIGSEGV/SIGABRT is always a C-side defect.
+- **A negative result is a real result.** "Both backends agreed across every adversarial input I tried" is useful signal — report it plainly, and say which inputs you tried, rather than inflating a non-divergence into a finding.
+- **Record confirmed finds.** For a reproduced C crash, write the record into the `cpython-review-findings` repo (`repro.py`, `evidence.txt` with the exit code + traceback, the implicated `c_sources` file, and `found_by: parity-checker`), and hand it to the `oom-reproducer` / dynamic-verification flow if a wider allocation-failure sweep is warranted.
+- **Start high-confidence, cap output.** Work the `high`-confidence pairs first. Report at most 10 divergences; note totals if more exist.

--- a/plugins/cpython-review-toolkit/commands/explore.md
+++ b/plugins/cpython-review-toolkit/commands/explore.md
@@ -37,14 +37,18 @@ Parse arguments into three categories:
 - `ft-races` → ft-race-scanner
 - `stw-safety` → stw-safety-checker
 - `lock-discipline` → lock-discipline-checker
+- `init-bypass` → init-bypass-checker
+- `parity` → parity-checker
 - `history` → git-history-analyzer
 - `all` → all agents (default)
 
 Note: `recursion`, `pyerr-clear`, `uninit-dealloc`, `ft-races`, `stw-safety`, and
-`lock-discipline` are the tree-sitter-based detectors (require `pip install
-tree-sitter tree-sitter-c`). The `tsan-report-analyzer` and `tsan-stress-generator`
-agents are on-demand tools (they consume/produce a ThreadSanitizer run on a
-`--disable-gil` build), not part of the static explore pipeline.
+`lock-discipline`, and `init-bypass` are the tree-sitter-based detectors (require
+`pip install tree-sitter tree-sitter-c`). The `tsan-report-analyzer`,
+`tsan-stress-generator`, and `oom-reproducer` agents are on-demand **dynamic**
+tools (they need a built interpreter — a `--disable-gil`+TSan build, or a build
+providing `_testcapi.set_nomemory`), not part of the static explore pipeline; see
+the `reproduce` command.
 
 **Options**:
 - `deep` → full detail, no output truncation
@@ -87,6 +91,7 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 - recursion-guard-auditor — native-stack-overflow SIGSEGV in recursion-prone slots (gh-154318, gh-154275)
 - pyerr-clear-auditor — exception-clobber in the destructor family (gh-152083)
 - uninitialized-dealloc-auditor — half-built object freed on an error path (gh-151815, gh-152851)
+- init-bypass-checker — NULL field deref after `__new__` bypass or a deletable member (gh-152954, gh-152817)
 
 **Group B — Memory safety**:
 3. null-safety-scanner
@@ -104,7 +109,10 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 **Group D — Maintenance and hygiene**:
 7. api-deprecation-tracker
 8. macro-hygiene-reviewer
-9. memory-pattern-analyzer
+9. memory-pattern-analyzer — alloc-size overflow + GC-track invariant (script-backed as of 0.7)
+
+**Group D2 — Differential parity** (only where a scope has a C accelerator with a shipped pure-Python twin):
+- parity-checker — behavioral divergence between e.g. `_decimal`/`_pydecimal`, `_io`/`_pyio`; a C crash where the twin raises is a confirmed, localized bug
 
 **Group E — Temporal analysis (runs last)**:
 10. git-history-analyzer

--- a/plugins/cpython-review-toolkit/commands/health.md
+++ b/plugins/cpython-review-toolkit/commands/health.md
@@ -27,6 +27,7 @@ Run all agents in summary mode to produce a quick health dashboard. Each agent r
 | Recursion Guards   | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Destructor PyErr   | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Uninit Dealloc     | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
+| Init Bypass        | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | FT Data Races      | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | STW Safety         | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |
 | Lock Discipline    | 🟢/🟡/🔴  | X/10  | N   | [1-line summary]               |

--- a/plugins/cpython-review-toolkit/commands/hotspots.md
+++ b/plugins/cpython-review-toolkit/commands/hotspots.md
@@ -18,6 +18,7 @@ Run the highest-value agents to find the worst functions to fix first: the crash
    - **recursion-guard-auditor** — native-stack-overflow SIGSEGV in recursion-prone slots
    - **pyerr-clear-auditor** — exception-clobber in the destructor family
    - **uninitialized-dealloc-auditor** — half-built object freed on an error path
+   - **init-bypass-checker** — NULL field deref after `__new__` bypass / a deletable member
    - **refcount-auditor** — find reference counting errors
    - **error-path-analyzer** — find error handling bugs
    - **c-complexity-analyzer** — find the hardest-to-maintain code

--- a/plugins/cpython-review-toolkit/commands/reproduce.md
+++ b/plugins/cpython-review-toolkit/commands/reproduce.md
@@ -1,0 +1,76 @@
+---
+description: "Turn a static allocation-failure finding into a reproduced crash via dense OOM injection"
+argument-hint: "[finding-or-snippet] [--python <cpython-build>]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
+---
+
+# Reproduce a Crash (dense OOM injection)
+
+Take a *static* candidate — from `uninitialized-dealloc-auditor`, `pyerr-clear-auditor`, `null-safety-scanner`, `error-path-analyzer`, or a `known-issues` `present` verdict — and try to turn it into a **reproduced crash with evidence** on a locally-built CPython.
+
+**Arguments:** "$ARGUMENTS"
+
+## Phase 0: Find a usable interpreter
+
+The harness needs a CPython build providing `_testcapi.set_nomemory`. Check, in order:
+1. An explicit `--python <path>` argument.
+2. A source checkout's `./python` (e.g. `~/projects/cpython/python`).
+3. A build matrix (e.g. `~/projects/python_build_matrix/builds/*/python`) — prefer a **debug** or **ASan** build; they turn silent corruption into loud assertions.
+
+Verify: `<python> -c "import _testcapi; print(hasattr(_testcapi,'set_nomemory'))"`.
+If none is available, report that and stop — do not fabricate a result.
+
+## Phase 1: Choose the target
+
+If the argument names a finding (file:line, function, or a scanner finding id), read that code and write the **smallest stdlib-only snippet** that reaches it. If the argument is already a snippet or a script path, use it directly.
+
+State explicitly which line you are trying to reach — Phase 4 depends on it.
+
+## Phase 2: Sweep
+
+Dispatch the **oom-reproducer** agent, or run directly:
+
+```bash
+python <plugin_root>/scripts/run_oom_sweep.py --python <build> --code '<snippet>' --max-n 300
+```
+
+Dense by default. Use `--stop-after 1` for existence proof, `--start-n` to skip startup allocations, `--script` for a longer payload.
+
+## Phase 3: Confirm and minimize
+
+On a crash: re-run to confirm determinism, then shrink the payload to the minimum that still crashes, and capture the faulthandler traceback and the crash index.
+
+## Phase 4: Report honestly
+
+```markdown
+# Reproduction Report
+
+## Target
+[static finding + file:line + which agent surfaced it]
+
+## Interpreter
+[path, build flavor, version]
+
+## Sweep
+- Range: 0..N (dense) | Outcomes: {...}
+- **Verdict**: REPRODUCED at index K  /  not reproduced in this range
+
+## Evidence
+[exit code + faulthandler traceback]
+
+## Assessment
+[Did the payload reach the flagged line? What is proven / not proven?]
+```
+
+**A negative result is a real result**: "every allocation failure on this path was handled cleanly" must be reported plainly, and does not by itself refute the static finding (the payload may not have reached the line).
+
+## Phase 5: Record
+
+For a reproduced crash, add/update the record in the `cpython-review-findings` repo — `repro.py`, `evidence.txt`, status `reproduced`, the crash index, the interpreter build, and `found_by` (the static agent that predicted it). Then regenerate its index.
+
+## Usage
+
+```
+/cpython-review-toolkit:reproduce Objects/templateobject.c:225
+/cpython-review-toolkit:reproduce 'import json; json.loads("[1,2,3]")' --python ~/projects/cpython/python
+```

--- a/plugins/cpython-review-toolkit/scripts/check_known_issues.py
+++ b/plugins/cpython-review-toolkit/scripts/check_known_issues.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import scan_ft_races
+import scan_init_bypass
 import scan_null_checks
 import scan_pyerr_clear
 import scan_recursion_guards
@@ -49,8 +50,9 @@ from scan_common import build_report, parse_common_args, resolve_roots
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 _DEFAULT_CATALOG = _DATA_DIR / "cpython_known_bugs.tsv"
 
-# Category -> scanner module. ``None`` means "no scanner exists yet"; such
-# entries are carried through as ``no_scanner`` so the catalog stays complete.
+# Category -> scanner module. A category present in the catalog but missing
+# here (or mapped to ``None``) is carried through as ``no_scanner`` so the
+# catalog stays complete. As of 0.7 every category has a scanner.
 CATEGORY_SCANNERS: dict[str, object] = {
     "recursion": scan_recursion_guards,
     "pyerr-clear": scan_pyerr_clear,
@@ -58,7 +60,7 @@ CATEGORY_SCANNERS: dict[str, object] = {
     "null-deref": scan_null_checks,
     "refcount": scan_refcounts,
     "tsan": scan_ft_races,
-    "init-bypass": None,
+    "init-bypass": scan_init_bypass,
 }
 
 # ± lines tolerated around a catalog line before a match is called "drifted".
@@ -71,11 +73,13 @@ _ABSENCE_CAVEAT = (
     "`absent`. Always read the file before concluding a bug is fixed."
 )
 _NO_SCANNER_CAVEAT = (
-    "Category `init-bypass` has no scanner yet; its entries are carried through "
-    "as `no_scanner` (informational) so the catalog stays complete, but they are "
-    "not cross-referenced against a fresh scan. (`tsan` is now scanned by "
-    "scan_ft_races, but note the caveat above: a data race carries no scannable "
-    "token at many sites, so `absent` there still is not proof of a fix.)"
+    "Every catalog category now has a scanner (as of 0.7). A category added to "
+    "the catalog without a matching entry in CATEGORY_SCANNERS is carried "
+    "through as `no_scanner` (informational) so the catalog stays complete, but "
+    "is not cross-referenced against a fresh scan. Note the caveat above still "
+    "applies to the scanned categories: a data race (tsan) or a native "
+    "stack overflow (recursion) carries no scannable token at many sites, so "
+    "`absent` there is not proof of a fix."
 )
 
 

--- a/plugins/cpython-review-toolkit/scripts/find_parity_pairs.py
+++ b/plugins/cpython-review-toolkit/scripts/find_parity_pairs.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Discover CPython's C-accelerator <-> pure-Python-twin module pairs.
+
+CPython ships several stdlib modules *twice*: a fast C accelerator and a pure
+Python implementation of the same public API. The pure-Python twin is a free
+differential oracle -- feed the same adversarial input to both backends and any
+divergence (a C-side segfault while the twin raises a clean exception, or two
+different exception types) is a localized, confirmed lead.
+
+This is a **discovery** script, not a bug scanner. It walks a CPython checkout
+and emits the inventory of dual implementations so the ``parity-checker`` agent
+knows what to differentially test. It reports, per pair:
+
+* the public module name (``decimal``, ``io``, ``heapq`` ...),
+* the pure-Python implementation path,
+* the C accelerator source path(s),
+* how the pair was detected, and
+* a confidence in the pairing.
+
+Two detection methods are used:
+
+1. **explicit ``_py*`` twin** -- a ``Lib/_py<name>.py`` file (e.g.
+   ``_pydecimal.py``, ``_pyio.py``, ``_pydatetime.py``). These are the
+   strongest, unambiguous dual implementations.
+2. **accelerator-import** -- a public module ``Lib/<name>.py`` (or a package
+   ``Lib/<name>/``) that imports its same-named C accelerator ``_<name>``
+   (``from _heapq import *``, ``from _json import make_scanner``, ...). The
+   pure-Python fallback lives inline in the public module.
+
+A pair discovered by *both* methods (``decimal``, ``io``, ``datetime`` ...) is
+merged and reported once.
+
+Usage:
+    python find_parity_pairs.py [path-to-cpython-checkout] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+
+# Confidence ordering used to sort the inventory (highest first).
+_CONFIDENCE_RANK = {"high": 0, "medium": 1, "low": 2}
+
+# A comment line never carries a real import; skip it during import detection.
+_COMMENT_LINE = re.compile(r"^\s*#")
+
+
+def _c_module_and_base(twin_stem: str) -> tuple[str, str]:
+    """Map a ``_py*`` twin stem to its C accelerator module name and base.
+
+    ``_pydecimal`` -> (``_decimal``, ``decimal``);
+    ``_py_abc``    -> (``_abc``, ``abc``);
+    ``_py_warnings`` -> (``_warnings``, ``warnings``).
+    """
+    rest = twin_stem[len("_py") :]
+    if rest.startswith("_"):
+        # Twin name already carries the accelerator's leading underscore.
+        return rest, rest[1:]
+    return "_" + rest, rest
+
+
+def _locate_c_sources(project_root: Path, c_module: str, base: str) -> list[str]:
+    """Return the C accelerator source path(s) for module ``c_module``.
+
+    Searches the conventional CPython layouts, in order:
+
+    * ``Modules/<c_module>/*.c``      (package accelerators: ``_decimal``, ``_io``)
+    * ``Modules/<c_module>module.c``  (``_datetimemodule.c``, ``_heapqmodule.c``)
+    * ``Modules/<c_module>.c``        (``_json.c``, ``_csv.c``, ``_pickle.c``)
+    * ``Python/<c_module>.c``         (``_warnings.c``)
+    * ``Objects/<base>object.c``      (last-resort; e.g. ``_pylong`` -> longobject.c)
+    """
+    sources: list[Path] = []
+    modules = project_root / "Modules"
+
+    pkg_dir = modules / c_module
+    if pkg_dir.is_dir():
+        # Non-recursive: skip vendored subtrees like Modules/_decimal/libmpdec.
+        sources.extend(sorted(pkg_dir.glob("*.c")))
+
+    for candidate in (
+        modules / f"{c_module}module.c",
+        modules / f"{c_module}.c",
+        project_root / "Python" / f"{c_module}.c",
+    ):
+        if candidate.is_file():
+            sources.append(candidate)
+
+    if not sources:
+        fallback = project_root / "Objects" / f"{base}object.c"
+        if fallback.is_file():
+            sources.append(fallback)
+
+    return [relpath(s, project_root) for s in sources]
+
+
+def _module_python_files(lib: Path, name: str) -> list[Path]:
+    """Return the Python file(s) making up public module ``name``.
+
+    A single-file module is ``Lib/<name>.py``; a package is every ``*.py`` one
+    level deep in ``Lib/<name>/`` (enough to reach the accelerator imports that
+    live in package submodules, e.g. ``Lib/json/scanner.py``).
+    """
+    single = lib / f"{name}.py"
+    if single.is_file():
+        return [single]
+    pkg = lib / name
+    if (pkg / "__init__.py").is_file():
+        return sorted(pkg.glob("*.py"))
+    return []
+
+
+def _detect_accelerator_import(files: list[Path], base: str) -> tuple[str, list[Path]]:
+    """Detect whether ``files`` import the ``_<base>`` C accelerator.
+
+    Returns ``(import_style, import_sites)`` where ``import_style`` is
+    ``"star"`` (``from _base import *`` -- a full replacement), ``"named"``
+    (a selective ``from _base import name`` / ``import _base``), or ``"none"``.
+    """
+    star_re = re.compile(rf"from\s+_{re.escape(base)}\s+import\s+\*")
+    from_re = re.compile(rf"from\s+_{re.escape(base)}\s+import\b")
+    import_re = re.compile(rf"(?:^|;)\s*import\s+_{re.escape(base)}\b")
+
+    style = "none"
+    sites: list[Path] = []
+    for filepath in files:
+        try:
+            text = filepath.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        hit = False
+        for line in text.splitlines():
+            if _COMMENT_LINE.match(line):
+                continue
+            if star_re.search(line):
+                style = "star"
+                hit = True
+            elif from_re.search(line) or import_re.search(line):
+                if style == "none":
+                    style = "named"
+                hit = True
+        if hit:
+            sites.append(filepath)
+    return style, sites
+
+
+def _confidence(detection: str, import_style: str, c_sources: list[str]) -> str:
+    """Grade the confidence of a discovered pair."""
+    if detection in ("explicit_py_twin", "both"):
+        # A dedicated _py* twin file is definitive evidence of a dual impl;
+        # only downgrade if we could not locate the C side to test against.
+        return "high" if c_sources else "medium"
+    # accelerator-import only: a star import replaces the whole module (strong),
+    # a selective import accelerates only some primitives (weaker).
+    return "medium" if import_style == "star" else "low"
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Discover C-accelerator / pure-Python-twin module pairs in a checkout."""
+    project_root, scan_root = resolve_roots(target)
+    lib = project_root / "Lib"
+
+    pairs: dict[str, dict] = {}
+    files_examined = 0
+    skipped: list[dict] = []
+
+    if not lib.is_dir():
+        skipped.append(
+            {"file": str(lib), "reason": "no Lib/ directory under project root"}
+        )
+
+    # --- Pass 1: explicit _py* twins ---------------------------------------
+    if lib.is_dir():
+        for twin in sorted(lib.glob("_py*.py")):
+            files_examined += 1
+            c_module, base = _c_module_and_base(twin.stem)
+            c_sources = _locate_c_sources(project_root, c_module, base)
+            pairs[base] = {
+                "type": "parity_pair",
+                "module": base,
+                "python_impl": relpath(twin, project_root),
+                "python_twin_module": twin.stem,
+                "c_module": c_module,
+                "c_sources": c_sources,
+                "detection": "explicit_py_twin",
+                "import_style": "none",
+                "import_sites": [],
+                "force_python_hint": f"import {twin.stem}",
+            }
+
+    # --- Pass 2: accelerator imports in public modules ---------------------
+    if lib.is_dir():
+        candidates: set[str] = set()
+        for entry in sorted(lib.iterdir()):
+            if entry.name.startswith("_"):
+                continue
+            if entry.is_file() and entry.suffix == ".py":
+                candidates.add(entry.stem)
+            elif entry.is_dir() and (entry / "__init__.py").is_file():
+                candidates.add(entry.name)
+
+        for name in sorted(candidates):
+            c_module = "_" + name
+            # Cheap gate: only inspect a module's Python source if a same-named
+            # C accelerator actually exists (avoids reading all of Lib/test/).
+            c_sources = _locate_c_sources(project_root, c_module, name)
+            if not c_sources:
+                continue
+            files = _module_python_files(lib, name)
+            if not files:
+                continue
+            if max_files and files_examined >= max_files:
+                break
+            files_examined += len(files)
+            import_style, sites = _detect_accelerator_import(files, name)
+            if import_style == "none":
+                continue
+            site_rel = [relpath(s, project_root) for s in sites]
+
+            existing = pairs.get(name)
+            if existing is not None:
+                # Already found as a _py* twin -> upgrade to "both" and enrich.
+                existing["detection"] = "both"
+                existing["import_style"] = import_style
+                existing["import_sites"] = site_rel
+                existing["python_dispatcher"] = site_rel[0] if site_rel else None
+                if not existing["c_sources"]:
+                    existing["c_sources"] = c_sources
+            else:
+                entry_point = files[0]
+                pairs[name] = {
+                    "type": "parity_pair",
+                    "module": name,
+                    "python_impl": relpath(entry_point, project_root),
+                    "python_twin_module": None,
+                    "c_module": c_module,
+                    "c_sources": c_sources,
+                    "detection": "accelerator_import",
+                    "import_style": import_style,
+                    "import_sites": site_rel,
+                    "force_python_hint": (
+                        f"block '{c_module}' in sys.modules before importing "
+                        f"{name} (the C accelerator shadows the pure-Python "
+                        "definitions in the same file)"
+                    ),
+                }
+
+    # --- Finalize ----------------------------------------------------------
+    findings: list[dict] = []
+    for pair in pairs.values():
+        pair["confidence"] = _confidence(
+            pair["detection"], pair["import_style"], pair["c_sources"]
+        )
+        findings.append(pair)
+
+    findings.sort(key=lambda p: (_CONFIDENCE_RANK.get(p["confidence"], 9), p["module"]))
+
+    by_confidence: dict[str, int] = defaultdict(int)
+    by_detection: dict[str, int] = defaultdict(int)
+    for pair in findings:
+        by_confidence[pair["confidence"]] += 1
+        by_detection[pair["detection"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_examined,
+        functions_analyzed=0,
+        findings=findings,
+        summary={
+            "total_pairs": len(findings),
+            "by_confidence": dict(by_confidence),
+            "by_detection": dict(by_detection),
+        },
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001 - top-level guard emits JSON error
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/run_oom_sweep.py
+++ b/plugins/cpython-review-toolkit/scripts/run_oom_sweep.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Dense out-of-memory sweep — turn a static candidate into a reproduced crash.
+
+CPython's ``_testcapi.set_nomemory(start, stop)`` installs a counting allocator
+across all three pymalloc domains (RAW / MEM / OBJ) that fails every allocation
+from the ``start``-th onward. Sweeping ``start`` densely over ``0..N`` exercises
+each allocation-failure path in a snippet in turn, which is exactly what drives
+the unchecked-allocation, half-constructed-object, and exception-clobber bugs
+this toolkit finds statically.
+
+Methodology (learned from real crashes — do not "optimize" these away):
+
+* **Dense sweep.** Try *every* integer in the range, never a sparse sample: a
+  crash window is often exactly one allocation wide.
+* **One subprocess per iteration.** A segfault kills the interpreter, so an
+  in-process loop would only ever see the first crash. Isolation also keeps a
+  corrupted heap from poisoning later iterations.
+* **Exit codes are the signal.** 139 / -11 = SIGSEGV, 134 / -6 = SIGABRT
+  (assertion / fatal error), 1 = a clean ``MemoryError`` (the *safe* path),
+  0 = the snippet completed before the allocator budget ran out.
+* ``faulthandler`` is enabled before arming, and the hooks are removed in a
+  ``finally`` so teardown itself does not fault.
+
+The interpreter under test must be a CPython build with ``_testcapi`` available
+(a normal ``./configure && make`` checkout has it; a debug or ASan build gives
+the best diagnostics). Point ``--python`` at it.
+
+Usage:
+    python run_oom_sweep.py --python ~/cpython/python --code 'x = {}.copy()'
+    python run_oom_sweep.py --python ~/cpython/python --script repro.py --max-n 400
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# Exit-code -> classification. Negative values are POSIX signal returns.
+SIGSEGV_CODES = frozenset({139, -11})
+SIGABRT_CODES = frozenset({134, -6})
+
+# Wrapper executed in the child. It arms the counting allocator, runs the
+# payload, and reports a clean MemoryError distinctly from a crash.
+_HARNESS_TEMPLATE = """\
+import faulthandler
+import sys
+
+faulthandler.enable()
+
+import _testcapi
+
+_PAYLOAD = {payload!r}
+
+_testcapi.set_nomemory({start})
+try:
+    exec(compile(_PAYLOAD, "<oom-payload>", "exec"), {{"__name__": "__main__"}})
+except MemoryError:
+    # The allocation failure was handled correctly: this is the SAFE outcome.
+    try:
+        _testcapi.remove_mem_hooks()
+    except Exception:
+        pass
+    sys.exit(1)
+except BaseException:
+    try:
+        _testcapi.remove_mem_hooks()
+    except Exception:
+        pass
+    # Any other exception is also a non-crash outcome; distinguish it from
+    # MemoryError so the caller can see unexpected error types.
+    sys.exit(2)
+finally:
+    try:
+        _testcapi.remove_mem_hooks()
+    except Exception:
+        pass
+sys.exit(0)
+"""
+
+
+def classify(returncode: int) -> str:
+    """Map a child exit code to an outcome name."""
+    if returncode in SIGSEGV_CODES:
+        return "segv"
+    if returncode in SIGABRT_CODES:
+        return "abort"
+    if returncode == 0:
+        return "completed"
+    if returncode == 1:
+        return "memory_error"
+    if returncode == 2:
+        return "other_exception"
+    if returncode < 0:
+        return f"signal_{-returncode}"
+    return f"exit_{returncode}"
+
+
+def is_crash(outcome: str) -> bool:
+    """True if the outcome represents a genuine crash (not a handled error)."""
+    return outcome in ("segv", "abort") or outcome.startswith("signal_")
+
+
+def run_one(python: str, payload: str, n: int, *, timeout: float = 30.0) -> dict:
+    """Run the payload once with allocation #n (and onward) failing."""
+    script = _HARNESS_TEMPLATE.format(payload=payload, start=n)
+    try:
+        proc = subprocess.run(
+            [python, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {"n": n, "outcome": "timeout", "returncode": None, "stderr": ""}
+    except OSError as e:
+        return {
+            "n": n,
+            "outcome": "spawn_error",
+            "returncode": None,
+            "stderr": str(e),
+        }
+    return {
+        "n": n,
+        "outcome": classify(proc.returncode),
+        "returncode": proc.returncode,
+        # Keep the tail: a faulthandler traceback lands at the end.
+        "stderr": proc.stderr[-4000:],
+    }
+
+
+def check_interpreter(python: str) -> str | None:
+    """Return an error string if the interpreter can't run the harness."""
+    probe = (
+        "import _testcapi, sys; "
+        "sys.exit(0 if hasattr(_testcapi, 'set_nomemory') else 3)"
+    )
+    try:
+        proc = subprocess.run(
+            [python, "-c", probe], capture_output=True, text=True, timeout=60
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return f"cannot run interpreter {python!r}: {e}"
+    if proc.returncode == 3:
+        return (
+            f"{python!r} has _testcapi but no set_nomemory() — "
+            "use a CPython build that provides it"
+        )
+    if proc.returncode != 0:
+        return (
+            f"{python!r} cannot import _testcapi (needed for OOM injection). "
+            "Use a CPython source build (./configure && make), not a "
+            "distro python without the test C extensions. "
+            f"stderr: {proc.stderr.strip()[:300]}"
+        )
+    return None
+
+
+def sweep(
+    python: str,
+    payload: str,
+    *,
+    max_n: int = 200,
+    start_n: int = 0,
+    timeout: float = 30.0,
+    stop_after: int = 0,
+) -> dict:
+    """Densely sweep the failing-allocation index and collect the outcomes.
+
+    ``stop_after`` > 0 stops once that many distinct crashes are found (0 =
+    sweep the whole range).
+    """
+    err = check_interpreter(python)
+    if err:
+        return {"error": err, "python": python}
+
+    results: list[dict] = []
+    crashes: list[dict] = []
+    outcome_counts: dict[str, int] = {}
+
+    for n in range(start_n, max_n):
+        r = run_one(python, payload, n, timeout=timeout)
+        results.append(r)
+        outcome_counts[r["outcome"]] = outcome_counts.get(r["outcome"], 0) + 1
+        if is_crash(r["outcome"]):
+            crashes.append(r)
+            if stop_after and len(crashes) >= stop_after:
+                break
+
+    first_crash = crashes[0] if crashes else None
+    return {
+        "python": python,
+        "payload": payload,
+        "range": {"start": start_n, "stop": max_n},
+        "iterations_run": len(results),
+        "outcome_counts": outcome_counts,
+        "crashes": crashes,
+        "first_crash": first_crash,
+        "reproduced": bool(crashes),
+        "summary": {
+            "total_crashes": len(crashes),
+            "crash_indices": [c["n"] for c in crashes],
+            "verdict": (
+                "REPRODUCED — allocation failure crashes the interpreter"
+                if crashes
+                else "no crash in this range (all failures handled cleanly)"
+            ),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Dense OOM-injection sweep to reproduce allocation-failure crashes.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            examples:
+              run_oom_sweep.py --python ./python --code 'import json; json.loads("[1,2]")'
+              run_oom_sweep.py --python ./python --script repro.py --max-n 500 --stop-after 1
+            """
+        ),
+    )
+    parser.add_argument(
+        "--python",
+        required=True,
+        help="CPython interpreter to test (must provide _testcapi.set_nomemory)",
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--code", help="Python snippet to run under OOM injection")
+    src.add_argument("--script", help="Path to a Python file to run")
+    parser.add_argument(
+        "--max-n", type=int, default=200, help="sweep 0..max-n (default 200)"
+    )
+    parser.add_argument(
+        "--start-n", type=int, default=0, help="first allocation index (default 0)"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=30.0, help="per-iteration timeout seconds"
+    )
+    parser.add_argument(
+        "--stop-after",
+        type=int,
+        default=0,
+        help="stop after N crashes (0 = full sweep)",
+    )
+    args = parser.parse_args()
+
+    if args.script:
+        try:
+            payload = Path(args.script).read_text(encoding="utf-8")
+        except OSError as e:
+            json.dump({"error": f"cannot read script: {e}"}, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            sys.exit(2)
+    else:
+        payload = args.code
+
+    try:
+        result = sweep(
+            args.python,
+            payload,
+            max_n=args.max_n,
+            start_n=args.start_n,
+            timeout=args.timeout,
+            stop_after=args.stop_after,
+        )
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_init_bypass.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_init_bypass.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for __init__-bypass NULL dereferences.
+
+The dangerous pattern: a C method/slot reads ``self->field`` and INCREFs it,
+calls it, or dereferences it with **no NULL check**, but the field can
+legitimately be NULL because construction can bypass the ``tp_init`` that would
+have set it. There are two ways the field becomes NULL:
+
+1. **``__new__`` / subclass bypass.** The type wires a ``tp_init`` that assigns
+   ``self->field`` but has no ``tp_new`` (and no ``DISALLOW_INSTANTIATION``), so
+   ``T.__new__(T)`` produces a zeroed object on which ``field`` is NULL and
+   ``__init__`` never ran.
+2. **A deletable member/getset.** The field is exposed via a ``PyMemberDef`` with
+   a deletable object type (``T_OBJECT`` / ``T_OBJECT_EX`` and the ``Py_``/``_Py_``
+   spellings, without ``READONLY``), so ``del obj.field`` leaves it NULL.
+
+A guard like ``if (self->field != Py_None)`` or ``if (!Py_IsNone(self->field))``
+is **not** a NULL guard: after the bypass the field is NULL, ``NULL != Py_None``
+is true, and control enters the crashing block.
+
+Confirmed exemplars this targets:
+  - gh-152954 — ``sqlite3.Connection.__new__`` bypass leaves ``row_factory`` NULL,
+    then ``Py_INCREF(self->row_factory)`` crashes (Modules/_sqlite/connection.c).
+  - gh-152817 — ``del cursor.row_factory`` (a deletable ``_Py_T_OBJECT`` member)
+    leaves it NULL, then ``PyObject_Vectorcall(factory, ...)`` crashes
+    (Modules/_sqlite/cursor.c).
+
+The scanner is deliberately high-recall: it flags candidates, an agent confirms
+the field can really be NULL and that the deref is genuinely unguarded. It
+cannot see cross-function guarantees (a caller that always sets the field).
+
+Usage:
+    python scan_init_bypass.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    find_assignments_in_scope,
+    find_calls_in_scope,
+    parse_bytes,
+    strip_comments,
+)
+
+# Member-type constants whose members are *deletable* (``del obj.attr`` sets the
+# slot to NULL). Ordered longest-first so regex alternation prefers the ``_EX``
+# spellings over their prefixes. READONLY members are excluded at match time.
+_DELETABLE_MEMBER_TYPES = (
+    "_Py_T_OBJECT_EX",
+    "Py_T_OBJECT_EX",
+    "T_OBJECT_EX",
+    "_Py_T_OBJECT",
+    "Py_T_OBJECT",
+    "T_OBJECT",
+)
+
+# A PyMemberDef entry: {"name", TYPE, offsetof(Struct, field), flags[, "doc"]}.
+# We capture the *struct field* (from offsetof — that's what ``self->field``
+# reads) and the flags text so READONLY members can be filtered.
+_MEMBER_ENTRY_RE = re.compile(
+    r'\{\s*"[^"]*"\s*,\s*'
+    r"(" + "|".join(_DELETABLE_MEMBER_TYPES) + r")\s*,\s*"
+    r"offsetof\s*\(\s*\w+\s*,\s*(\w+)\s*\)\s*,\s*"
+    r"([^}]*)\}"
+)
+
+# tp_init wiring (PyType_Slot form and static-PyTypeObject designated form).
+_TP_INIT_SLOT_RE = re.compile(r"\bPy_tp_init\s*,\s*(?:&\s*)?(\w+)")
+_TP_INIT_DESIG_RE = re.compile(
+    r"\.tp_init\s*=\s*(?:\(\s*[\w\s\*]+\)\s*)?(?:&\s*)?(\w+)"
+)
+# Any of these tokens means the type controls instantiation itself (a real
+# tp_new, or an explicit disallow) — the __new__-bypass reasoning does not apply,
+# so we conservatively disable the bypass signal for the whole file.
+_TP_NEW_TOKENS_RE = re.compile(r"\bPy_tp_new\b|\.tp_new\s*=|\bDISALLOW_INSTANTIATION\b")
+
+# Sinks that crash on a NULL argument.
+# Single-argument refcount ops (Py_XINCREF / Py_IncRef are NULL-safe — excluded).
+_INCREF_SINKS = frozenset({"Py_INCREF", "Py_NewRef", "_Py_NewRef"})
+# Call family — the first argument (the callable / receiver object) must be
+# non-NULL.
+_CALL_SINKS = frozenset(
+    {
+        "PyObject_Call",
+        "PyObject_CallObject",
+        "PyObject_CallNoArgs",
+        "PyObject_CallOneArg",
+        "PyObject_CallFunction",
+        "PyObject_CallFunctionObjArgs",
+        "PyObject_CallMethod",
+        "PyObject_CallMethodObjArgs",
+        "PyObject_CallMethodOneArg",
+        "PyObject_CallMethodNoArgs",
+        "PyObject_Vectorcall",
+        "PyObject_VectorcallDict",
+        "PyObject_VectorcallMethod",
+        "_PyObject_Vectorcall",
+        "_PyObject_CallNoArgs",
+        "_PyObject_FastCall",
+        "_PyObject_FastCallDict",
+    }
+)
+# Dereference macros — the single argument is dereferenced immediately.
+_DEREF_SINKS = frozenset(
+    {"Py_TYPE", "Py_SIZE", "Py_REFCNT", "Py_SET_TYPE", "Py_SET_SIZE"}
+)
+
+# RHS ends in ``-> field`` (possibly through casts), e.g. ``self->row_factory``
+# or ``((FooObject *)self)->row_factory``.
+_TRAILING_FIELD_RE = re.compile(r"->\s*(\w+)\s*$")
+# A function call token (``foo(``) — used to reject call results as field aliases.
+_CALL_TOKEN_RE = re.compile(r"[A-Za-z_]\w*\s*\(")
+
+
+def _receiver_name(func: dict) -> str | None:
+    """Return the identifier of the first parameter (the ``self`` receiver)."""
+    params = func["parameters"].strip()
+    if not params:
+        return None
+    first = params.split(",")[0]
+    idents = re.findall(r"[A-Za-z_]\w*", first)
+    return idents[-1] if idents else None
+
+
+def _fields_set_in_init(func: dict, recv: str) -> set[str]:
+    """Return struct fields the init function assigns via ``recv->field``."""
+    body = strip_comments(func["body"])
+    esc = re.escape(recv)
+    fields: set[str] = set()
+    # Direct assignment: recv->field = ...  (but not ==, >=, <=, !=).
+    for m in re.finditer(rf"\b{esc}\s*->\s*(\w+)\s*=(?!=)", body):
+        fields.add(m.group(1))
+    # Py_SETREF / Py_XSETREF(recv->field, ...).
+    for m in re.finditer(rf"Py_X?SETREF\s*\(\s*{esc}\s*->\s*(\w+)", body):
+        fields.add(m.group(1))
+    return fields
+
+
+def _collect_nullable_fields(source: str, functions: list[dict]) -> dict[str, set[str]]:
+    """Map ``field_name -> {reasons}`` for fields that can legitimately be NULL.
+
+    Reasons: ``deletable_member`` (a deletable PyMemberDef entry) and
+    ``new_bypass`` (assigned only in a tp_init with no tp_new to protect it).
+    """
+    clean = strip_comments(source)
+    nullable: dict[str, set[str]] = defaultdict(set)
+
+    # (1) Deletable members.
+    for m in _MEMBER_ENTRY_RE.finditer(clean):
+        _mtype, field, flags = m.group(1), m.group(2), m.group(3)
+        if "READONLY" in flags:
+            continue
+        nullable[field].add("deletable_member")
+
+    # (2) __new__ / subclass bypass — only when the file wires a tp_init but no
+    # tp_new / DISALLOW_INSTANTIATION anywhere.
+    if _TP_NEW_TOKENS_RE.search(clean):
+        return nullable
+    init_names = set(_TP_INIT_SLOT_RE.findall(clean))
+    init_names |= set(_TP_INIT_DESIG_RE.findall(clean))
+    if not init_names:
+        return nullable
+    # Argument Clinic renames the real body to ``<slot>_impl``; accept both.
+    init_fn_names = set()
+    for n in init_names:
+        init_fn_names.add(n)
+        init_fn_names.add(n + "_impl")
+    for func in functions:
+        if func["name"] not in init_fn_names:
+            continue
+        recv = _receiver_name(func)
+        if not recv:
+            continue
+        for field in _fields_set_in_init(func, recv):
+            nullable[field].add("new_bypass")
+
+    return nullable
+
+
+def _first_arg(args_text: str) -> str:
+    """Return the first top-level (paren-depth 0) argument of a call."""
+    depth = 0
+    for i, ch in enumerate(args_text):
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            return args_text[:i].strip()
+    return args_text.strip()
+
+
+def _resolve_target_field(
+    target: str, nullable: dict[str, set[str]], aliases: dict[str, str]
+) -> str | None:
+    """Return the nullable field a sink argument reads, or None."""
+    t = target.strip()
+    if t in aliases:
+        return aliases[t]
+    m = _TRAILING_FIELD_RE.search(t)
+    if m and m.group(1) in nullable:
+        return m.group(1)
+    return None
+
+
+def _build_aliases(
+    func: dict, nullable: dict[str, set[str]], source_bytes: bytes
+) -> dict[str, str]:
+    """Map local vars assigned a bare ``recv->field`` read to that field."""
+    aliases: dict[str, str] = {}
+    for assign in find_assignments_in_scope(func["body_node"], source_bytes):
+        var = assign["variable"]
+        if not var.isidentifier():
+            continue
+        rhs = assign["value_text"].strip()
+        m = _TRAILING_FIELD_RE.search(rhs)
+        if not m or m.group(1) not in nullable:
+            continue
+        # Reject call results (``foo()->field``) — only plain reads / casts alias.
+        if _CALL_TOKEN_RE.search(rhs):
+            continue
+        aliases[var] = m.group(1)
+    return aliases
+
+
+def _has_null_guard(body: str, field: str, aliases: dict[str, str]) -> bool:
+    """True if ``body`` NULL-checks the field (or an alias of it) at all.
+
+    Recognised guards: ``== NULL`` / ``!= NULL``; ``!field``; the truthiness
+    idioms ``field &&`` / ``&& field)`` / ``if (field)`` / ``field ?``; and a
+    ``CHECK_*`` macro over the field.
+
+    Deliberately NOT guards: ``field != Py_None`` / ``Py_IsNone(field)`` — after
+    an __init__ bypass the field is NULL, so those branches are still entered.
+    The truthiness patterns require the field to be the *whole* boolean operand
+    (terminated by ``)`` / ``&&`` / ``||`` / ``?``); ``&& field != Py_None`` is a
+    comparison, not a truthiness check, and is correctly NOT matched.
+    """
+    names = {field} | {a for a, f in aliases.items() if f == field}
+    for n in names:
+        esc = re.escape(n)
+        # field == NULL / field != NULL
+        if re.search(rf"\b{esc}\b\s*(?:==|!=)\s*NULL", body):
+            return True
+        # !field  (but not !=, and not !field-> / !field.)
+        if re.search(rf"!\s*(?:\w+\s*->\s*)?\b{esc}\b(?!\s*(?:=|->|\.))", body):
+            return True
+        # field &&  (short-circuit AND — the dominant CPython NULL-guard idiom)
+        if re.search(rf"\b{esc}\b\s*&&", body):
+            return True
+        # ... && field  as a trailing boolean operand (followed by ) && || ?)
+        if re.search(rf"&&\s*(?:\w+\s*->\s*)?\b{esc}\b\s*(?:\)|&&|\|\||\?)", body):
+            return True
+        # bare if (field) / if (self->field)
+        if re.search(rf"\bif\s*\(\s*(?:\w+\s*->\s*)?\b{esc}\b\s*\)", body):
+            return True
+        # field ?  (ternary condition)
+        if re.search(rf"\b{esc}\b\s*\?", body):
+            return True
+        # CHECK_* macro naming the field
+        if re.search(rf"\bCHECK_\w+\s*\([^)]*\b{esc}\b", body):
+            return True
+    return False
+
+
+def _sink_kind(name: str) -> str | None:
+    if name in _INCREF_SINKS:
+        return "incref"
+    if name in _CALL_SINKS:
+        return "call"
+    if name in _DEREF_SINKS:
+        return "deref"
+    return None
+
+
+def _check_function(
+    func: dict, nullable: dict[str, set[str]], source_bytes: bytes, tree
+) -> list[dict]:
+    """Flag unguarded sink reads of a nullable field in one function."""
+    body = strip_comments(func["body"])
+    aliases = _build_aliases(func, nullable, source_bytes)
+
+    findings: list[dict] = []
+    seen: set[tuple[str, int]] = set()
+    for call in find_calls_in_scope(func["body_node"], source_bytes):
+        name = call["function_name"]
+        kind = _sink_kind(name)
+        if kind is None:
+            continue
+        args = call["arguments_text"]
+        target = _first_arg(args) if kind == "call" else args.strip()
+        field = _resolve_target_field(target, nullable, aliases)
+        if field is None:
+            continue
+        if _has_null_guard(body, field, aliases):
+            continue
+        line = call["start_line"]
+        if is_suppressed_by_comment(source_bytes, tree, line):
+            continue
+        dedupe_key = (field, line)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+
+        reasons = sorted(nullable[field])
+        confidence = "high" if "deletable_member" in reasons else "medium"
+        mechanism = (
+            "a deletable member/getset (del obj.attr leaves it NULL)"
+            if "deletable_member" in reasons
+            else "a __new__/subclass bypass of tp_init (T.__new__(T) leaves it NULL)"
+        )
+        verb = {
+            "incref": f"Py_INCREF'd via {name}()",
+            "call": f"used as the callable in {name}()",
+            "deref": f"dereferenced via {name}()",
+        }[kind]
+        findings.append(
+            {
+                "type": "init_bypass_null_deref",
+                "function": func["name"],
+                "field": field,
+                "sink": name,
+                "reason": ",".join(reasons),
+                "line": line,
+                "confidence": confidence,
+                "detail": (
+                    f"'{field}' is {verb} with no NULL guard, but it can be NULL "
+                    f"via {mechanism}. A guard such as '{field} != Py_None' or "
+                    f"'Py_IsNone({field})' does NOT protect this — after the "
+                    f"bypass the field is NULL. Add 'if ({field} == NULL)' (or "
+                    f"initialize it in tp_new) before the deref."
+                ),
+            }
+        )
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for __init__-bypass NULL dereferences of nullable object fields."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    total_functions = 0
+    files_analyzed = 0
+    files_with_nullable_fields = 0
+    total_nullable_fields = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # noqa: BLE001 - defensive parse guard
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        total_functions += len(functions)
+
+        source = source_bytes.decode("utf-8", errors="replace")
+        nullable = _collect_nullable_fields(source, functions)
+        if not nullable:
+            continue
+        files_with_nullable_fields += 1
+        total_nullable_fields += len(nullable)
+
+        rel = relpath(filepath, project_root)
+        for func in functions:
+            for f in _check_function(func, nullable, source_bytes, tree):
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_confidence: dict[str, int] = defaultdict(int)
+    by_reason: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_confidence[f["confidence"]] += 1
+        by_reason[f["reason"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_confidence": dict(by_confidence),
+            "by_reason": dict(by_reason),
+        },
+        files_with_nullable_fields=files_with_nullable_fields,
+        total_nullable_fields=total_nullable_fields,
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # noqa: BLE001 - top-level JSON error envelope
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cpython-review-toolkit/scripts/scan_memory_patterns.py
+++ b/plugins/cpython-review-toolkit/scripts/scan_memory_patterns.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Scan CPython C source for memory-management bugs beyond reference counting.
+
+Three syntactic checks, each with a distinct finding ``type``. All default to
+silence — a candidate surfaces only when a specific, high-signal shape matches.
+
+1. ``alloc_size_overflow`` (bug class R5; cf. gh-3493, gh-1779)
+   A ``PyMem_Malloc(n * size)`` / ``malloc(count * sizeof(T))`` /
+   ``PyMem_Realloc(p, n * k)`` where a multiply operand derives from a
+   **Python-controlled** value (a ``PyLong_As*`` / ``PyObject_Length`` /
+   ``Py_SIZE`` result, or a ``PyArg_Parse*`` output) and there is **no** prior
+   bounds guard (a ``PY_SSIZE_T_MAX / size`` division check, a ``< 0`` sign
+   check, ``__builtin_mul_overflow`` …). ``PyMem_New`` / ``PyMem_Resize`` /
+   ``*_Calloc`` do the overflow check internally and are treated as SAFE — they
+   never reach this check because their size arguments are separate operands,
+   not a bare ``a * b``.
+
+2. ``gc_untrack_without_track`` (bug class O6; cf. gh-152107 OOM-0006/0017)
+   A constructor allocates with ``PyObject_GC_New*`` and, on an early error
+   path, frees the object (``Py_DECREF`` / ``Py_XDECREF`` / ``Py_CLEAR``)
+   *before* any ``PyObject_GC_Track`` on it. If ``tp_dealloc`` then runs the
+   untrack macro (``_PyObject_GC_UNTRACK``) on the never-tracked object the GC
+   invariant is violated.
+
+3. ``mismatched_alloc_free`` (allocator-family mismatch)
+   The SAME variable is allocated by one allocator family and freed by another
+   in the same function (``PyMem_Malloc`` freed with ``free`` / ``PyObject_Free``,
+   ``PyObject_Malloc`` freed with ``PyMem_Free``, ``malloc`` freed with
+   ``PyMem_Free`` …). The three families (raw ``malloc``, ``PyMem_*``,
+   ``PyObject_*``) draw from different heaps and must not be crossed.
+
+Usage:
+    python scan_memory_patterns.py [path] [--max-files N]
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_common import (
+    build_report,
+    deduplicate_findings,
+    discover_c_files,
+    is_suppressed_by_comment,
+    parse_common_args,
+    relpath,
+    resolve_roots,
+)
+from tree_sitter_utils import (
+    extract_functions,
+    find_assignments_in_scope,
+    find_calls_in_scope,
+    get_node_text,
+    parse_bytes,
+    walk_descendants,
+)
+
+# ---------------------------------------------------------------------------
+# Check 1: integer overflow in an allocation size
+# ---------------------------------------------------------------------------
+
+# Allocators whose size argument is a single expression we can inspect for a
+# Python-derived multiply. calloc-family (PyMem_Calloc / PyObject_Calloc /
+# calloc) and PyMem_New / PyMem_Resize are omitted deliberately: they take the
+# count and element size as *separate* arguments and overflow-check internally.
+# {allocator: index of the size argument}
+_SIZE_ARG_INDEX = {
+    "malloc": 0,
+    "PyMem_Malloc": 0,
+    "PyMem_RawMalloc": 0,
+    "PyObject_Malloc": 0,
+    "realloc": 1,
+    "PyMem_Realloc": 1,
+    "PyMem_RawRealloc": 1,
+    "PyObject_Realloc": 1,
+}
+
+# Calls whose result is a Python-controlled integer. Used both as
+# return-assignment taint sources and as inline operands inside the multiply
+# (the call's name appears as an identifier in the sub-tree).
+_TAINT_CALL_NAMES = frozenset(
+    {
+        "PyLong_AsSsize_t",
+        "PyLong_AsLong",
+        "PyLong_AsLongLong",
+        "PyLong_AsSize_t",
+        "PyLong_AsUnsignedLong",
+        "PyLong_AsUnsignedLongLong",
+        "PyLong_AsUnsignedLongMask",
+        "PyNumber_AsSsize_t",
+        "PyObject_Length",
+        "PyObject_Size",
+        "PyObject_LengthHint",
+        "PySequence_Length",
+        "PySequence_Size",
+        "PyMapping_Length",
+        "PyMapping_Size",
+        "PyTuple_Size",
+        "PyTuple_GET_SIZE",
+        "PyList_Size",
+        "PyList_GET_SIZE",
+        "PyBytes_Size",
+        "PyBytes_GET_SIZE",
+        "PyByteArray_Size",
+        "PyByteArray_GET_SIZE",
+        "PyUnicode_GetLength",
+        "PyUnicode_GET_LENGTH",
+        "Py_SIZE",
+    }
+)
+
+_PYARG_PARSERS = frozenset(
+    {
+        "PyArg_ParseTuple",
+        "PyArg_ParseTupleAndKeywords",
+        "PyArg_Parse",
+        "PyArg_ParseStack",
+        "PyArg_VaParse",
+        "_PyArg_ParseTupleAndKeywords",
+        "_PyArg_ParseStack",
+        "_PyArg_ParseStackAndKeywords",
+    }
+)
+
+# Textual signals that an overflow guard precedes the allocation. Any of these
+# in the pre-allocation body text suppresses the finding (deliberately
+# over-broad — silence beats noise on a tree this large).
+_MAX_CONSTS = (
+    "PY_SSIZE_T_MAX",
+    "PY_SIZE_MAX",
+    "SIZE_MAX",
+    "SSIZE_MAX",
+    "INT_MAX",
+    "UINT_MAX",
+    "LONG_MAX",
+    "ULONG_MAX",
+    "SIZE_T_MAX",
+)
+_OVERFLOW_HELPERS = (
+    "__builtin_mul_overflow",
+    "__builtin_add_overflow",
+    "_Py_size_",
+    "_Py_memory_repeat",
+    "size_overflow",
+    "overflow",
+)
+
+_LEADING_CAST_RE = re.compile(r"^\s*(?:\(\s*[\w\s\*]+\)\s*)+")
+_HEAD_CALL_RE = re.compile(r"([A-Za-z_]\w*)\s*\(")
+_BARE_IDENT_RE = re.compile(r"^\s*(?:\(\s*[\w\s\*]+\)\s*)*([A-Za-z_]\w*)\s*$")
+_ADDR_IDENT_RE = re.compile(r"&\s*([A-Za-z_]\w*)")
+
+
+def _head_call(value_text: str) -> str | None:
+    """Return the leading call identifier of an expression, past one cast run."""
+    s = _LEADING_CAST_RE.sub("", value_text.strip())
+    m = _HEAD_CALL_RE.match(s)
+    return m.group(1) if m else None
+
+
+def _bare_ident(text: str) -> str | None:
+    """Return the identifier if ``text`` is a (possibly cast) single ident."""
+    m = _BARE_IDENT_RE.match(text)
+    return m.group(1) if m else None
+
+
+def _collect_taint(func: dict, source_bytes: bytes) -> tuple[set[str], set[str]]:
+    """Return (strong_tainted_vars, weak_tainted_vars) for a function body.
+
+    Strong: assigned from a PyLong_As* / length / Py_SIZE call.
+    Weak: written through ``&var`` by a PyArg_Parse* call (broad; lower signal).
+    """
+    strong: set[str] = set()
+    weak: set[str] = set()
+
+    for assign in find_assignments_in_scope(func["body_node"], source_bytes):
+        var = assign["variable"]
+        if not var.isidentifier():
+            continue
+        head = _head_call(assign["value_text"])
+        if head in _TAINT_CALL_NAMES:
+            strong.add(var)
+
+    for call in find_calls_in_scope(func["body_node"], source_bytes, _PYARG_PARSERS):
+        for m in _ADDR_IDENT_RE.finditer(call["arguments_text"]):
+            weak.add(m.group(1))
+
+    return strong, weak
+
+
+def _multiplies(node, source_bytes: bytes):
+    """Yield binary_expression nodes whose operator is ``*`` within ``node``."""
+    for bx in walk_descendants(node, "binary_expression"):
+        op = bx.child_by_field_name("operator")
+        if op is not None and get_node_text(op, source_bytes) == "*":
+            yield bx
+
+
+def _has_overflow_guard(pre_text: str, variables: set[str]) -> bool:
+    """True if the pre-allocation text carries any overflow / bounds guard."""
+    if any(c in pre_text for c in _MAX_CONSTS):
+        return True
+    if any(h in pre_text for h in _OVERFLOW_HELPERS):
+        return True
+    for v in variables:
+        vre = re.escape(v)
+        if re.search(rf"\b{vre}\b\s*(?:<|<=|>|>=|==|!=)\s*0\b", pre_text):
+            return True
+        if re.search(rf"\b0\b\s*(?:<|<=|>|>=|==|!=)\s*\b{vre}\b", pre_text):
+            return True
+    return False
+
+
+def _check_alloc_size_overflow(func: dict, source_bytes: bytes, tree) -> list[dict]:
+    strong, weak = _collect_taint(func, source_bytes)
+    if not strong and not weak:
+        return []
+
+    body = func["body"]
+    body_start = func["body_node"].start_byte + 1
+
+    findings: list[dict] = []
+    for call in find_calls_in_scope(func["body_node"], source_bytes):
+        idx = _SIZE_ARG_INDEX.get(call["function_name"])
+        if idx is None:
+            continue
+        args_node = call["node"].child_by_field_name("arguments")
+        if args_node is None:
+            continue
+        arg_nodes = [c for c in args_node.named_children if c.type != "comment"]
+        if idx >= len(arg_nodes):
+            continue
+        size_arg = arg_nodes[idx]
+
+        for bx in _multiplies(size_arg, source_bytes):
+            idents = {
+                get_node_text(n, source_bytes)
+                for n in walk_descendants(bx, "identifier")
+            }
+            strong_hit = idents & (strong | _TAINT_CALL_NAMES)
+            weak_hit = idents & weak
+            if not strong_hit and not weak_hit:
+                continue
+
+            guard_vars = (strong_hit - _TAINT_CALL_NAMES) | weak_hit
+            offset = call["start_byte"] - body_start
+            pre_text = body[:offset] if 0 <= offset <= len(body) else body
+            if _has_overflow_guard(pre_text, guard_vars):
+                continue
+
+            line = call["start_line"]
+            if is_suppressed_by_comment(source_bytes, tree, line):
+                continue
+
+            confidence = "medium" if strong_hit else "low"
+            operand = ", ".join(sorted(idents & (strong | weak | _TAINT_CALL_NAMES)))
+            findings.append(
+                {
+                    "type": "alloc_size_overflow",
+                    "function": func["name"],
+                    "line": line,
+                    "confidence": confidence,
+                    "detail": (
+                        f"{call['function_name']}() size argument multiplies a "
+                        f"Python-controlled operand ({operand}) with no visible "
+                        f"overflow guard (no PY_SSIZE_T_MAX/size division check, "
+                        f"< 0 sign check, or __builtin_mul_overflow before the "
+                        f"call). The product can wrap, under-allocating the "
+                        f"buffer (bug class R5; cf. gh-3493, gh-1779). Use "
+                        f"PyMem_New/PyMem_Calloc (they overflow-check) or add an "
+                        f"explicit `n > PY_SSIZE_T_MAX / size` guard."
+                    ),
+                }
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 2: GC-track invariant (free before GC_Track)
+# ---------------------------------------------------------------------------
+
+_GC_ALLOCATORS = frozenset(
+    {
+        "PyObject_GC_New",
+        "PyObject_GC_NewVar",
+        "_PyObject_GC_New",
+        "_PyObject_GC_NewVar",
+        "PyObject_GC_NewWithExtra",
+    }
+)
+_GC_TRACK_NAMES = frozenset(
+    {"PyObject_GC_Track", "_PyObject_GC_TRACK", "PyObject_GC_TRACK"}
+)
+_EARLY_FREE_NAMES = frozenset({"Py_DECREF", "Py_XDECREF", "Py_CLEAR"})
+
+# The O6 bug is only reachable when tp_dealloc runs the untrack *macro*
+# (_PyObject_GC_UNTRACK), which unconditionally unlinks an object it assumes is
+# tracked. The public *function* PyObject_GC_UnTrack guards with
+# _PyObject_GC_IS_TRACKED and is safe on a never-tracked object, so the
+# ubiquitous "Py_DECREF(op) on error before GC_Track" idiom is correct wherever
+# the untrack macro is absent. Gating on macro presence (below) suppresses the
+# entire safe-idiom population — nearly all of Modules/ uses only the function.
+_GC_UNTRACK_MACRO = b"_PyObject_GC_UNTRACK"
+
+
+def _check_gc_untrack_without_track(
+    func: dict, source_bytes: bytes, tree
+) -> list[dict]:
+    # File-level gate: no untrack macro anywhere -> no tp_dealloc in this file
+    # can hit the O6 shape, so the free-before-track idiom here is safe.
+    if _GC_UNTRACK_MACRO not in source_bytes:
+        return []
+
+    body_node = func["body_node"]
+
+    # Objects allocated with a GC allocator (var -> allocator, first assign).
+    gc_objs: dict[str, str] = {}
+    for assign in find_assignments_in_scope(body_node, source_bytes):
+        var = assign["variable"]
+        if not var.isidentifier() or var in gc_objs:
+            continue
+        head = _head_call(assign["value_text"])
+        if head in _GC_ALLOCATORS:
+            gc_objs[var] = head
+    if not gc_objs:
+        return []
+
+    # Earliest GC_Track byte per object.
+    track_off: dict[str, int] = {}
+    for call in find_calls_in_scope(body_node, source_bytes, _GC_TRACK_NAMES):
+        ident = _bare_ident(call["arguments_text"])
+        if ident in gc_objs and ident not in track_off:
+            track_off[ident] = call["start_byte"]
+
+    # Earliest early-free byte per object.
+    free_info: dict[str, dict] = {}
+    for call in find_calls_in_scope(body_node, source_bytes, _EARLY_FREE_NAMES):
+        ident = _bare_ident(call["arguments_text"])
+        if ident in gc_objs and ident not in free_info:
+            free_info[ident] = {
+                "byte": call["start_byte"],
+                "line": call["start_line"],
+                "func": call["function_name"],
+            }
+
+    findings: list[dict] = []
+    for var, allocator in gc_objs.items():
+        free = free_info.get(var)
+        if free is None:
+            continue
+        track = track_off.get(var)
+        # Flag only when the free precedes every track of this object (or no
+        # track exists at all): the object can reach tp_dealloc's untrack macro
+        # having never been placed in the GC list.
+        if track is not None and track <= free["byte"]:
+            continue
+        line = free["line"]
+        if is_suppressed_by_comment(source_bytes, tree, line):
+            continue
+        findings.append(
+            {
+                "type": "gc_untrack_without_track",
+                "function": func["name"],
+                "line": line,
+                "confidence": "low",
+                "detail": (
+                    f"'{var}' is allocated via {allocator}() and freed with "
+                    f"{free['func']}() on an error path before any "
+                    f"PyObject_GC_Track({var}) — if tp_dealloc runs the untrack "
+                    f"macro (_PyObject_GC_UNTRACK) on the never-tracked object "
+                    f"the GC invariant is violated (bug class O6; cf. gh-152107 "
+                    f"OOM-0006/0017). Ensure the error path does not reach an "
+                    f"unconditional untrack, or track before the fallible step."
+                ),
+            }
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 3: mismatched alloc/free family
+# ---------------------------------------------------------------------------
+
+_ALLOC_FAMILY = {
+    "malloc": "raw",
+    "calloc": "raw",
+    "realloc": "raw",
+    "reallocarray": "raw",
+    "strdup": "raw",
+    "PyMem_Malloc": "pymem",
+    "PyMem_Calloc": "pymem",
+    "PyMem_Realloc": "pymem",
+    "PyMem_New": "pymem",
+    "PyMem_RawMalloc": "pymem_raw",
+    "PyMem_RawCalloc": "pymem_raw",
+    "PyMem_RawRealloc": "pymem_raw",
+    "PyObject_Malloc": "pyobject",
+    "PyObject_Calloc": "pyobject",
+    "PyObject_Realloc": "pyobject",
+}
+_FREE_FAMILY = {
+    "free": "raw",
+    "PyMem_Free": "pymem",
+    "PyMem_Del": "pymem",
+    "PyMem_DEL": "pymem",
+    "PyMem_RawFree": "pymem_raw",
+    "PyObject_Free": "pyobject",
+    "PyObject_Del": "pyobject",
+    "PyObject_DEL": "pyobject",
+    "PyObject_GC_Del": "pyobject",
+}
+_FAMILY_LABEL = {
+    "raw": "malloc/free",
+    "pymem": "PyMem_*",
+    "pymem_raw": "PyMem_Raw*",
+    "pyobject": "PyObject_*",
+}
+
+
+def _check_mismatched_alloc_free(func: dict, source_bytes: bytes, tree) -> list[dict]:
+    body_node = func["body_node"]
+
+    alloc_family: dict[str, set[str]] = defaultdict(set)
+    alloc_line: dict[str, int] = {}
+    for assign in find_assignments_in_scope(body_node, source_bytes):
+        var = assign["variable"]
+        if not var.isidentifier():
+            continue
+        head = _head_call(assign["value_text"])
+        fam = _ALLOC_FAMILY.get(head)
+        if fam is not None:
+            alloc_family[var].add(fam)
+            alloc_line.setdefault(var, assign["start_line"])
+
+    if not alloc_family:
+        return []
+
+    findings: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for call in find_calls_in_scope(body_node, source_bytes, frozenset(_FREE_FAMILY)):
+        free_fam = _FREE_FAMILY[call["function_name"]]
+        ident = _bare_ident(call["arguments_text"])
+        if ident is None:
+            continue
+        families = alloc_family.get(ident)
+        # Require an unambiguous single allocation family for the variable.
+        if not families or len(families) != 1:
+            continue
+        alloc_fam = next(iter(families))
+        if alloc_fam == free_fam:
+            continue
+        key = (ident, alloc_fam, free_fam)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        line = call["start_line"]
+        if is_suppressed_by_comment(source_bytes, tree, line):
+            continue
+        findings.append(
+            {
+                "type": "mismatched_alloc_free",
+                "function": func["name"],
+                "line": line,
+                "confidence": "high",
+                "detail": (
+                    f"'{ident}' is allocated with the "
+                    f"{_FAMILY_LABEL[alloc_fam]} family but freed with "
+                    f"{call['function_name']}() ({_FAMILY_LABEL[free_fam]}). "
+                    f"CPython's three allocator families draw from different "
+                    f"heaps and must not be crossed — undefined behavior. Free "
+                    f"with the matching family."
+                ),
+            }
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _check_function(func: dict, source_bytes: bytes, tree) -> list[dict]:
+    findings: list[dict] = []
+    findings.extend(_check_alloc_size_overflow(func, source_bytes, tree))
+    findings.extend(_check_gc_untrack_without_track(func, source_bytes, tree))
+    findings.extend(_check_mismatched_alloc_free(func, source_bytes, tree))
+    return findings
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Scan for allocation-size overflow, GC-track, and allocator-mismatch bugs."""
+    project_root, scan_root = resolve_roots(target)
+
+    findings: list[dict] = []
+    total_functions = 0
+    files_analyzed = 0
+    skipped: list[dict] = []
+
+    for filepath in discover_c_files(scan_root, max_files=max_files):
+        try:
+            source_bytes = filepath.read_bytes()
+        except OSError as e:
+            skipped.append({"file": str(filepath), "reason": str(e)})
+            continue
+
+        try:
+            tree = parse_bytes(source_bytes)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"file": str(filepath), "reason": f"parse: {e}"})
+            continue
+
+        functions = extract_functions(tree, source_bytes)
+        if not functions:
+            continue
+
+        files_analyzed += 1
+        rel = relpath(filepath, project_root)
+
+        for func in functions:
+            total_functions += 1
+            for f in _check_function(func, source_bytes, tree):
+                f["file"] = rel
+                findings.append(f)
+
+    findings = deduplicate_findings(findings)
+
+    by_type: dict[str, int] = defaultdict(int)
+    by_confidence: dict[str, int] = defaultdict(int)
+    for f in findings:
+        by_type[f["type"]] += 1
+        by_confidence[f["confidence"]] += 1
+
+    return build_report(
+        project_root=project_root,
+        scan_root=scan_root,
+        files_analyzed=files_analyzed,
+        functions_analyzed=total_functions,
+        findings=findings,
+        summary={
+            "total_findings": len(findings),
+            "by_type": dict(by_type),
+            "by_confidence": dict(by_confidence),
+        },
+        skipped_files=skipped,
+    )
+
+
+def main() -> None:
+    try:
+        target, max_files = parse_common_args(sys.argv[1:])
+        result = analyze(target, max_files=max_files)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:  # pragma: no cover - defensive
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_known_issues.py
+++ b/tests/test_check_known_issues.py
@@ -151,26 +151,27 @@ class TestCheckKnownIssues(unittest.TestCase):
 
     # --- no_scanner passthrough --------------------------------------------
 
-    def test_no_scanner_category_passes_through(self):
-        # `init-bypass` has no scanner yet -> carried through as no_scanner.
-        # (`tsan` IS scanned now, by scan_ft_races.)
+    def test_unmapped_category_passes_through_as_no_scanner(self):
+        # As of 0.7 every shipped category has a scanner, so this exercises the
+        # forward-compatibility path: a catalog category with no CATEGORY_SCANNERS
+        # entry is carried through as no_scanner rather than crashing the run.
         report = self._run(
             {"Objects/present.c": _PRESENT_DEALLOC},
             [
                 (
-                    "INIT-1",
+                    "FUTURE-1",
                     "Objects/present.c",
                     0,
-                    "init-bypass",
+                    "not-a-known-category",
                     "0",
-                    "__new__ bypass",
+                    "a category added to the catalog before its scanner exists",
                 ),
             ],
         )
-        self.assertEqual(self._result_for(report, "INIT-1")["status"], "no_scanner")
-        self.assertEqual(report["bug_rollup"]["INIT-1"], "no_scanner")
+        self.assertEqual(self._result_for(report, "FUTURE-1")["status"], "no_scanner")
+        self.assertEqual(report["bug_rollup"]["FUTURE-1"], "no_scanner")
         # no_scanner entries are never scanned and never actionable findings.
-        self.assertFalse(any(f["bug_id"] == "INIT-1" for f in report["findings"]))
+        self.assertFalse(any(f["bug_id"] == "FUTURE-1" for f in report["findings"]))
 
     # --- bug_rollup collapsing multi-site bugs -----------------------------
 

--- a/tests/test_find_parity_pairs.py
+++ b/tests/test_find_parity_pairs.py
@@ -1,0 +1,150 @@
+"""Tests for find_parity_pairs.py -- C-accelerator / pure-Python-twin discovery."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestFindParityPairs(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("find_parity_pairs")
+
+    def _analyze(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    def _pair(self, result, module):
+        return next((f for f in result["findings"] if f["module"] == module), None)
+
+    # --- both detection methods --------------------------------------------
+
+    def test_discovers_explicit_py_twin_and_accelerator_import(self):
+        result = self._analyze(
+            {
+                # Explicit _py* twin pair: _pydecimal.py <-> Modules/_decimal/.
+                "Lib/_pydecimal.py": "def Decimal(x):\n    return x\n",
+                "Modules/_decimal/_decimal.c": '#include "Python.h"\n',
+                # Accelerator-import pair: heapq.py imports the _heapq C module.
+                "Lib/heapq.py": (
+                    "def heappush(heap, item):\n"
+                    "    heap.append(item)\n"
+                    "try:\n"
+                    "    from _heapq import *\n"
+                    "except ImportError:\n"
+                    "    pass\n"
+                ),
+                "Modules/_heapqmodule.c": '#include "Python.h"\n',
+            }
+        )
+
+        decimal = self._pair(result, "decimal")
+        self.assertIsNotNone(decimal, "explicit _py* twin not discovered")
+        self.assertEqual(decimal["detection"], "explicit_py_twin")
+        self.assertEqual(decimal["python_impl"], "Lib/_pydecimal.py")
+        self.assertEqual(decimal["python_twin_module"], "_pydecimal")
+        self.assertEqual(decimal["c_module"], "_decimal")
+        self.assertIn("Modules/_decimal/_decimal.c", decimal["c_sources"])
+        self.assertEqual(decimal["confidence"], "high")
+
+        heapq = self._pair(result, "heapq")
+        self.assertIsNotNone(heapq, "accelerator-import pair not discovered")
+        self.assertEqual(heapq["detection"], "accelerator_import")
+        self.assertEqual(heapq["python_impl"], "Lib/heapq.py")
+        self.assertIsNone(heapq["python_twin_module"])
+        self.assertEqual(heapq["c_module"], "_heapq")
+        self.assertIn("Modules/_heapqmodule.c", heapq["c_sources"])
+        self.assertEqual(heapq["import_style"], "star")
+
+    # --- merging: a pair found by BOTH methods is reported once ------------
+
+    def test_twin_plus_accelerator_import_merges_to_both(self):
+        result = self._analyze(
+            {
+                "Lib/_pydatetime.py": "def datetime():\n    pass\n",
+                "Lib/datetime.py": (
+                    "try:\n"
+                    "    from _datetime import *\n"
+                    "except ImportError:\n"
+                    "    from _pydatetime import *\n"
+                ),
+                "Modules/_datetimemodule.c": '#include "Python.h"\n',
+            }
+        )
+        datetime_pairs = [f for f in result["findings"] if f["module"] == "datetime"]
+        self.assertEqual(len(datetime_pairs), 1, "pair should be merged, not doubled")
+        pair = datetime_pairs[0]
+        self.assertEqual(pair["detection"], "both")
+        self.assertEqual(pair["python_impl"], "Lib/_pydatetime.py")
+        self.assertEqual(pair["import_style"], "star")
+        self.assertEqual(pair["python_dispatcher"], "Lib/datetime.py")
+        self.assertEqual(pair["confidence"], "high")
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_pure_python_module_without_c_counterpart_not_reported(self):
+        result = self._analyze(
+            {
+                "Lib/foo.py": "def foo():\n    return 42\n",
+                # A pure-Python helper that imports an UNRELATED C module must
+                # not turn foo into a parity pair.
+                "Lib/bar.py": "from _thread import RLock\n",
+            }
+        )
+        self.assertIsNone(self._pair(result, "foo"))
+        self.assertIsNone(self._pair(result, "bar"))
+        self.assertIsNone(self._pair(result, "thread"))
+        self.assertEqual(result["findings"], [])
+
+    def test_named_import_only_is_low_confidence(self):
+        # csv.py selectively imports primitives from _csv (partial acceleration),
+        # not a full `import *` replacement -> lower confidence than a twin.
+        result = self._analyze(
+            {
+                "Lib/csv.py": "from _csv import Error, writer, reader\n",
+                "Modules/_csv.c": '#include "Python.h"\n',
+            }
+        )
+        csv = self._pair(result, "csv")
+        self.assertIsNotNone(csv)
+        self.assertEqual(csv["detection"], "accelerator_import")
+        self.assertEqual(csv["import_style"], "named")
+        self.assertEqual(csv["confidence"], "low")
+
+    # --- CPython-specific edge: package-level accelerator import -----------
+
+    def test_package_submodule_accelerator_import_is_discovered(self):
+        # json's accelerator import lives in a submodule (json/scanner.py), not
+        # in json/__init__.py -- the package must still be discovered.
+        result = self._analyze(
+            {
+                "Lib/json/__init__.py": "from .scanner import make_scanner\n",
+                "Lib/json/scanner.py": "from _json import make_scanner as c\n",
+                "Modules/_json.c": '#include "Python.h"\n',
+            }
+        )
+        json_pair = self._pair(result, "json")
+        self.assertIsNotNone(json_pair)
+        self.assertEqual(json_pair["detection"], "accelerator_import")
+        self.assertEqual(json_pair["python_impl"], "Lib/json/__init__.py")
+        self.assertIn("Lib/json/scanner.py", json_pair["import_sites"])
+        self.assertIn("Modules/_json.c", json_pair["c_sources"])
+
+    # --- envelope shape ----------------------------------------------------
+
+    def test_envelope_shape(self):
+        result = self._analyze({"Lib/foo.py": "x = 1\n"})
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+        for key in ("total_pairs", "by_confidence", "by_detection"):
+            self.assertIn(key, result["summary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_oom_sweep.py
+++ b/tests/test_run_oom_sweep.py
@@ -1,0 +1,137 @@
+"""Tests for run_oom_sweep.py — the dense OOM-injection reproducer harness.
+
+These tests must run anywhere, so they do not require a CPython source build.
+The classification/aggregation logic is tested directly, and the subprocess
+layer is exercised with a stubbed ``run_one``.
+"""
+
+import unittest
+
+from helpers import import_script
+
+
+class TestClassify(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("run_oom_sweep")
+
+    def test_signal_exit_codes(self):
+        # Both the shell-style (128+n) and negative-signal spellings.
+        self.assertEqual(self.mod.classify(139), "segv")
+        self.assertEqual(self.mod.classify(-11), "segv")
+        self.assertEqual(self.mod.classify(134), "abort")
+        self.assertEqual(self.mod.classify(-6), "abort")
+
+    def test_clean_outcomes(self):
+        self.assertEqual(self.mod.classify(0), "completed")
+        self.assertEqual(self.mod.classify(1), "memory_error")
+        self.assertEqual(self.mod.classify(2), "other_exception")
+
+    def test_other_signal_and_exit(self):
+        self.assertEqual(self.mod.classify(-9), "signal_9")
+        self.assertEqual(self.mod.classify(42), "exit_42")
+
+    def test_is_crash(self):
+        self.assertTrue(self.mod.is_crash("segv"))
+        self.assertTrue(self.mod.is_crash("abort"))
+        self.assertTrue(self.mod.is_crash("signal_9"))
+        # A handled MemoryError is the SAFE outcome, not a crash.
+        self.assertFalse(self.mod.is_crash("memory_error"))
+        self.assertFalse(self.mod.is_crash("completed"))
+        self.assertFalse(self.mod.is_crash("timeout"))
+
+
+class TestSweep(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("run_oom_sweep")
+        # Neutralize the interpreter probe; these tests stub run_one.
+        self.mod.check_interpreter = lambda python: None
+
+    def _stub(self, outcomes):
+        """Make run_one return a canned outcome per index."""
+
+        def fake_run_one(python, payload, n, *, timeout=30.0):
+            outcome = outcomes.get(n, "memory_error")
+            return {
+                "n": n,
+                "outcome": outcome,
+                "returncode": 139 if outcome == "segv" else 1,
+                "stderr": "",
+            }
+
+        self.mod.run_one = fake_run_one
+
+    def test_no_crash_reports_safe(self):
+        self._stub({})
+        r = self.mod.sweep("py", "pass", max_n=5)
+        self.assertFalse(r["reproduced"])
+        self.assertEqual(r["summary"]["total_crashes"], 0)
+        self.assertEqual(r["outcome_counts"]["memory_error"], 5)
+        self.assertIsNone(r["first_crash"])
+
+    def test_crash_is_reported_with_index(self):
+        self._stub({3: "segv"})
+        r = self.mod.sweep("py", "pass", max_n=6)
+        self.assertTrue(r["reproduced"])
+        self.assertEqual(r["summary"]["crash_indices"], [3])
+        self.assertEqual(r["first_crash"]["n"], 3)
+        self.assertIn("REPRODUCED", r["summary"]["verdict"])
+
+    def test_dense_sweep_covers_every_index(self):
+        seen = []
+
+        def fake_run_one(python, payload, n, *, timeout=30.0):
+            seen.append(n)
+            return {"n": n, "outcome": "memory_error", "returncode": 1, "stderr": ""}
+
+        self.mod.run_one = fake_run_one
+        self.mod.sweep("py", "pass", max_n=8)
+        # Dense, not sampled — a crash window can be one allocation wide.
+        self.assertEqual(seen, list(range(8)))
+
+    def test_stop_after_halts_early(self):
+        self._stub({1: "segv", 2: "segv", 3: "segv"})
+        r = self.mod.sweep("py", "pass", max_n=10, stop_after=2)
+        self.assertEqual(r["summary"]["total_crashes"], 2)
+        # Stopped right after the second crash rather than finishing the range.
+        self.assertLess(r["iterations_run"], 10)
+
+    def test_start_n_offsets_the_range(self):
+        self._stub({})
+        r = self.mod.sweep("py", "pass", start_n=5, max_n=9)
+        self.assertEqual(r["range"], {"start": 5, "stop": 9})
+        self.assertEqual(r["iterations_run"], 4)
+
+    def test_interpreter_guard_short_circuits(self):
+        self.mod.check_interpreter = lambda python: "no _testcapi"
+        r = self.mod.sweep("py", "pass", max_n=5)
+        self.assertIn("error", r)
+        self.assertNotIn("crashes", r)
+
+
+class TestHarnessTemplate(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("run_oom_sweep")
+
+    def test_template_arms_and_disarms(self):
+        script = self.mod._HARNESS_TEMPLATE.format(payload="x = 1", start=7)
+        # Arms the counting allocator at the requested index.
+        self.assertIn("set_nomemory(7)", script)
+        # Always removes the hooks so teardown itself cannot fault.
+        self.assertIn("remove_mem_hooks", script)
+        # faulthandler is enabled before arming.
+        self.assertLess(
+            script.index("faulthandler.enable"), script.index("set_nomemory")
+        )
+        # A handled MemoryError exits 1 (the SAFE outcome), not 0.
+        self.assertIn("sys.exit(1)", script)
+
+    def test_payload_is_embedded_safely(self):
+        # Quotes/newlines in the payload must not break the wrapper.
+        payload = 'x = "quoted\'s"\ny = 2\n'
+        script = self.mod._HARNESS_TEMPLATE.format(payload=payload, start=0)
+        self.assertIn(repr(payload), script)
+        compile(script, "<harness>", "exec")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_init_bypass.py
+++ b/tests/test_scan_init_bypass.py
@@ -1,0 +1,267 @@
+"""Tests for scan_init_bypass.py — __init__-bypass NULL dereferences.
+
+Grounded in two confirmed CPython crashes:
+  - gh-152954: sqlite3.Connection.__new__ bypass -> NULL row_factory -> Py_INCREF
+  - gh-152817: del cursor.row_factory -> NULL -> PyObject_Vectorcall
+"""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanInitBypass(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_init_bypass")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    # --- true positives ----------------------------------------------------
+
+    def test_deletable_member_incref_is_flagged(self):
+        # A T_OBJECT_EX member (deletable via `del obj.cb`) is Py_INCREF'd with
+        # no NULL guard.
+        result = self._findings(
+            {
+                "Modules/foo.c": (
+                    '#include "Python.h"\n'
+                    "typedef struct { PyObject_HEAD PyObject *cb; } FooObject;\n"
+                    "static void\n"
+                    "foo_use(PyObject *op)\n"
+                    "{\n"
+                    "    FooObject *self = (FooObject *)op;\n"
+                    "    Py_INCREF(self->cb);\n"
+                    "}\n"
+                    "static PyMemberDef foo_members[] = {\n"
+                    '    {"cb", T_OBJECT_EX, offsetof(FooObject, cb), 0},\n'
+                    "    {NULL}\n"
+                    "};\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["type"] == "init_bypass_null_deref"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["function"], "foo_use")
+        self.assertEqual(f["field"], "cb")
+        self.assertEqual(f["sink"], "Py_INCREF")
+        self.assertEqual(f["confidence"], "high")
+        self.assertIn("deletable_member", f["reason"])
+        # Findings carry the documented envelope keys.
+        for key in ("type", "function", "line", "confidence", "detail", "file"):
+            self.assertIn(key, f)
+
+    def test_deletable_field_vectorcall_via_alias_is_flagged(self):
+        # Mirrors gh-152817: `!Py_IsNone(self->factory)` is NOT a NULL guard, and
+        # the factory is aliased into a local before the call.
+        result = self._findings(
+            {
+                "Modules/bar.c": (
+                    "typedef struct { PyObject_HEAD PyObject *factory; } BarObject;\n"
+                    "static PyObject *\n"
+                    "bar_call(PyObject *op)\n"
+                    "{\n"
+                    "    BarObject *self = (BarObject *)op;\n"
+                    "    if (!Py_IsNone(self->factory)) {\n"
+                    "        PyObject *f = self->factory;\n"
+                    "        PyObject *args[] = { op };\n"
+                    "        return PyObject_Vectorcall(f, args, 1, NULL);\n"
+                    "    }\n"
+                    "    Py_RETURN_NONE;\n"
+                    "}\n"
+                    "static PyMemberDef bar_members[] = {\n"
+                    '    {"factory", Py_T_OBJECT_EX, offsetof(BarObject, factory), 0},\n'
+                    "    {NULL}\n"
+                    "};\n"
+                )
+            }
+        )
+        f = next((f for f in result["findings"] if f["field"] == "factory"), None)
+        self.assertIsNotNone(f)
+        self.assertEqual(f["sink"], "PyObject_Vectorcall")
+        self.assertEqual(f["confidence"], "high")
+
+    def test_new_bypass_field_incref_is_flagged(self):
+        # Mirrors gh-152954: field set only in tp_init, no tp_new -> NULL after
+        # T.__new__(T). `!= Py_None` is not a NULL guard.
+        result = self._findings(
+            {
+                "Modules/conn.c": (
+                    "typedef struct { PyObject_HEAD PyObject *row_factory; } ConnObject;\n"
+                    "static int\n"
+                    "conn_init_impl(ConnObject *self, PyObject *args)\n"
+                    "{\n"
+                    "    self->row_factory = Py_NewRef(Py_None);\n"
+                    "    return 0;\n"
+                    "}\n"
+                    "static PyObject *\n"
+                    "conn_make_cursor(PyObject *op)\n"
+                    "{\n"
+                    "    ConnObject *self = (ConnObject *)op;\n"
+                    "    if (self->row_factory != Py_None) {\n"
+                    "        Py_INCREF(self->row_factory);\n"
+                    "    }\n"
+                    "    Py_RETURN_NONE;\n"
+                    "}\n"
+                    "static PyType_Slot conn_slots[] = {\n"
+                    "    {Py_tp_init, conn_init_impl},\n"
+                    "    {0, NULL},\n"
+                    "};\n"
+                )
+            }
+        )
+        f = next(
+            (f for f in result["findings"] if f["function"] == "conn_make_cursor"),
+            None,
+        )
+        self.assertIsNotNone(f)
+        self.assertEqual(f["field"], "row_factory")
+        self.assertEqual(f["reason"], "new_bypass")
+        self.assertEqual(f["confidence"], "medium")
+
+    # --- true negatives ----------------------------------------------------
+
+    def test_explicit_null_guard_is_suppressed(self):
+        result = self._findings(
+            {
+                "Modules/baz.c": (
+                    "typedef struct { PyObject_HEAD PyObject *cb; } BazObject;\n"
+                    "static void\n"
+                    "baz_use(PyObject *op)\n"
+                    "{\n"
+                    "    BazObject *self = (BazObject *)op;\n"
+                    "    if (self->cb == NULL) {\n"
+                    "        return;\n"
+                    "    }\n"
+                    "    Py_INCREF(self->cb);\n"
+                    "}\n"
+                    "static PyMemberDef baz_members[] = {\n"
+                    '    {"cb", T_OBJECT_EX, offsetof(BazObject, cb), 0},\n'
+                    "    {NULL}\n"
+                    "};\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_truthiness_guard_is_suppressed(self):
+        # `if (self->msg && ...)` IS a NULL guard (the ImportError_str idiom).
+        result = self._findings(
+            {
+                "Modules/exc.c": (
+                    "typedef struct { PyObject_HEAD PyObject *msg; } ExcObject;\n"
+                    "static PyObject *\n"
+                    "exc_str(PyObject *op)\n"
+                    "{\n"
+                    "    ExcObject *self = (ExcObject *)op;\n"
+                    "    if (self->msg && PyUnicode_Check(self->msg)) {\n"
+                    "        return Py_NewRef(self->msg);\n"
+                    "    }\n"
+                    "    Py_RETURN_NONE;\n"
+                    "}\n"
+                    "static PyMemberDef exc_members[] = {\n"
+                    '    {"msg", Py_T_OBJECT_EX, offsetof(ExcObject, msg), 0},\n'
+                    "    {NULL}\n"
+                    "};\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_readonly_member_is_not_nullable(self):
+        # A READONLY member cannot be deleted, so it is not treated as nullable.
+        result = self._findings(
+            {
+                "Modules/qux.c": (
+                    "typedef struct { PyObject_HEAD PyObject *owner; } QuxObject;\n"
+                    "static void\n"
+                    "qux_use(PyObject *op)\n"
+                    "{\n"
+                    "    QuxObject *self = (QuxObject *)op;\n"
+                    "    Py_INCREF(self->owner);\n"
+                    "}\n"
+                    "static PyMemberDef qux_members[] = {\n"
+                    '    {"owner", Py_T_OBJECT_EX, offsetof(QuxObject, owner), Py_READONLY},\n'
+                    "    {NULL}\n"
+                    "};\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_tp_new_present_disables_bypass(self):
+        # When the type wires a tp_new (controls instantiation), the
+        # __new__-bypass reasoning does not apply.
+        result = self._findings(
+            {
+                "Modules/conn.c": (
+                    "typedef struct { PyObject_HEAD PyObject *row_factory; } ConnObject;\n"
+                    "static int\n"
+                    "conn_init_impl(ConnObject *self, PyObject *args)\n"
+                    "{\n"
+                    "    self->row_factory = Py_NewRef(Py_None);\n"
+                    "    return 0;\n"
+                    "}\n"
+                    "static PyObject *\n"
+                    "conn_make_cursor(PyObject *op)\n"
+                    "{\n"
+                    "    ConnObject *self = (ConnObject *)op;\n"
+                    "    if (self->row_factory != Py_None) {\n"
+                    "        Py_INCREF(self->row_factory);\n"
+                    "    }\n"
+                    "    Py_RETURN_NONE;\n"
+                    "}\n"
+                    "static PyType_Slot conn_slots[] = {\n"
+                    "    {Py_tp_new, conn_new},\n"
+                    "    {Py_tp_init, conn_init_impl},\n"
+                    "    {0, NULL},\n"
+                    "};\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    def test_comment_suppression(self):
+        result = self._findings(
+            {
+                "Modules/foo.c": (
+                    "typedef struct { PyObject_HEAD PyObject *cb; } FooObject;\n"
+                    "static void\n"
+                    "foo_use(PyObject *op)\n"
+                    "{\n"
+                    "    FooObject *self = (FooObject *)op;\n"
+                    "    /* intentional: cb cannot be NULL on this path */\n"
+                    "    Py_INCREF(self->cb);\n"
+                    "}\n"
+                    "static PyMemberDef foo_members[] = {\n"
+                    '    {"cb", T_OBJECT_EX, offsetof(FooObject, cb), 0},\n'
+                    "    {NULL}\n"
+                    "};\n"
+                )
+            }
+        )
+        self.assertEqual(result["findings"], [])
+
+    # --- envelope ----------------------------------------------------------
+
+    def test_envelope_shape(self):
+        result = self._findings(
+            {"Modules/foo.c": "static void foo(PyObject *self) { }\n"}
+        )
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_memory_patterns.py
+++ b/tests/test_scan_memory_patterns.py
@@ -1,0 +1,325 @@
+"""Tests for scan_memory_patterns.py — allocation-size overflow, GC-track, and
+allocator-family mismatch checks."""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+
+class TestScanMemoryPatterns(unittest.TestCase):
+    def setUp(self):
+        self.mod = import_script("scan_memory_patterns")
+
+    def _findings(self, files):
+        with TempProject(files) as root:
+            return self.mod.analyze(str(root))
+
+    def _of_type(self, result, type_name):
+        return [f for f in result["findings"] if f["type"] == type_name]
+
+    # === Check 1: alloc_size_overflow =====================================
+
+    def test_alloc_overflow_python_derived_size_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "make_buffer(PyObject *self, PyObject *arg)\n"
+                    "{\n"
+                    "    Py_ssize_t n = PyLong_AsSsize_t(arg);\n"
+                    "    int *buf = PyMem_Malloc(n * sizeof(int));\n"
+                    "    if (buf == NULL) return PyErr_NoMemory();\n"
+                    "    return (PyObject *)buf;\n"
+                    "}\n"
+                )
+            }
+        )
+        hits = self._of_type(result, "alloc_size_overflow")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["function"], "make_buffer")
+        self.assertEqual(hits[0]["confidence"], "medium")
+
+    def test_alloc_overflow_with_max_guard_is_safe(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "make_buffer(PyObject *self, PyObject *arg)\n"
+                    "{\n"
+                    "    Py_ssize_t n = PyLong_AsSsize_t(arg);\n"
+                    "    if (n < 0 || n > PY_SSIZE_T_MAX / sizeof(int))\n"
+                    "        return NULL;\n"
+                    "    int *buf = PyMem_Malloc(n * sizeof(int));\n"
+                    "    return (PyObject *)buf;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "alloc_size_overflow"), [])
+
+    def test_alloc_overflow_pymem_new_is_safe(self):
+        # PyMem_New overflow-checks internally; count/size are separate args,
+        # never a bare `a * b`, so it is never inspected.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "make_buffer(PyObject *self, PyObject *arg)\n"
+                    "{\n"
+                    "    Py_ssize_t n = PyLong_AsSsize_t(arg);\n"
+                    "    int *buf = PyMem_New(int, n);\n"
+                    "    return (PyObject *)buf;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "alloc_size_overflow"), [])
+
+    def test_alloc_overflow_constant_multiply_is_safe(self):
+        # No Python-derived operand -> a sizeof-only constant multiply is silent.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void *\n"
+                    "make_fixed(void)\n"
+                    "{\n"
+                    "    return PyMem_Malloc(16 * sizeof(int));\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "alloc_size_overflow"), [])
+
+    def test_alloc_overflow_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static PyObject *\n"
+                    "make_buffer(PyObject *self, PyObject *arg)\n"
+                    "{\n"
+                    "    Py_ssize_t n = PyLong_AsSsize_t(arg);\n"
+                    "    /* safety: n is validated by the caller */\n"
+                    "    int *buf = PyMem_Malloc(n * sizeof(int));\n"
+                    "    return (PyObject *)buf;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "alloc_size_overflow"), [])
+
+    # === Check 2: gc_untrack_without_track ================================
+
+    def test_gc_free_before_track_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(FooObject *op)\n"
+                    "{\n"
+                    "    _PyObject_GC_UNTRACK(op);\n"
+                    "    Py_XDECREF(op->attr);\n"
+                    "    PyObject_GC_Del(op);\n"
+                    "}\n"
+                    "\n"
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) {\n"
+                    "        Py_DECREF(op);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    PyObject_GC_Track(op);\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        hits = self._of_type(result, "gc_untrack_without_track")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["function"], "foo_new")
+
+    def test_gc_safe_function_untrack_is_not_gated_in(self):
+        # File uses the safe *function* PyObject_GC_UnTrack, never the macro,
+        # so the free-before-track idiom here cannot hit the O6 bug -> silent.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(FooObject *op)\n"
+                    "{\n"
+                    "    PyObject_GC_UnTrack(op);\n"
+                    "    Py_XDECREF(op->attr);\n"
+                    "    PyObject_GC_Del(op);\n"
+                    "}\n"
+                    "\n"
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) {\n"
+                    "        Py_DECREF(op);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    PyObject_GC_Track(op);\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "gc_untrack_without_track"), [])
+
+    def test_gc_track_before_free_is_safe(self):
+        # Object is tracked before the fallible step; the later free is safe.
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "bar_dealloc(BarObject *op)\n"
+                    "{\n"
+                    "    _PyObject_GC_UNTRACK(op);\n"
+                    "    PyObject_GC_Del(op);\n"
+                    "}\n"
+                    "\n"
+                    "static PyObject *\n"
+                    "bar_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    BarObject *op = PyObject_GC_New(BarObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = NULL;\n"
+                    "    PyObject_GC_Track(op);\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) {\n"
+                    "        Py_DECREF(op);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "gc_untrack_without_track"), [])
+
+    def test_gc_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "foo_dealloc(FooObject *op)\n"
+                    "{\n"
+                    "    _PyObject_GC_UNTRACK(op);\n"
+                    "    PyObject_GC_Del(op);\n"
+                    "}\n"
+                    "\n"
+                    "static PyObject *\n"
+                    "foo_new(PyTypeObject *type)\n"
+                    "{\n"
+                    "    FooObject *op = PyObject_GC_New(FooObject, type);\n"
+                    "    if (op == NULL) return NULL;\n"
+                    "    op->attr = PyObject_GetIter(type);\n"
+                    "    if (op->attr == NULL) {\n"
+                    "        /* intentional: dealloc tolerates the untracked object */\n"
+                    "        Py_DECREF(op);\n"
+                    "        return NULL;\n"
+                    "    }\n"
+                    "    PyObject_GC_Track(op);\n"
+                    "    return (PyObject *)op;\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "gc_untrack_without_track"), [])
+
+    # === Check 3: mismatched_alloc_free ===================================
+
+    def test_mismatch_pymem_alloc_raw_free_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "frob(void)\n"
+                    "{\n"
+                    "    char *buf = PyMem_Malloc(64);\n"
+                    "    do_work(buf);\n"
+                    "    free(buf);\n"
+                    "}\n"
+                )
+            }
+        )
+        hits = self._of_type(result, "mismatched_alloc_free")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["function"], "frob")
+        self.assertEqual(hits[0]["confidence"], "high")
+
+    def test_mismatch_pyobject_alloc_pymem_free_flagged(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "frob(void)\n"
+                    "{\n"
+                    "    void *p = PyObject_Malloc(128);\n"
+                    "    PyMem_Free(p);\n"
+                    "}\n"
+                )
+            }
+        )
+        hits = self._of_type(result, "mismatched_alloc_free")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["function"], "frob")
+
+    def test_mismatch_matching_family_is_safe(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "frob(void)\n"
+                    "{\n"
+                    "    char *buf = PyMem_Malloc(64);\n"
+                    "    do_work(buf);\n"
+                    "    PyMem_Free(buf);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "mismatched_alloc_free"), [])
+
+    def test_mismatch_comment_suppression(self):
+        result = self._findings(
+            {
+                "Objects/foo.c": (
+                    "static void\n"
+                    "frob(void)\n"
+                    "{\n"
+                    "    char *buf = PyMem_Malloc(64);\n"
+                    "    /* nolint: ownership handed to a raw-free API */\n"
+                    "    free(buf);\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertEqual(self._of_type(result, "mismatched_alloc_free"), [])
+
+    # === Envelope =========================================================
+
+    def test_envelope_shape(self):
+        result = self._findings({"Objects/foo.c": "static void foo(void) { }\n"})
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_analyzed",
+            "functions_analyzed",
+            "findings",
+            "summary",
+        ):
+            self.assertIn(key, result)
+        self.assertIn("by_type", result["summary"])
+        self.assertIn("by_confidence", result["summary"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **`oom-reproducer` + `run_oom_sweep.py` + the `reproduce` command** — the dynamic layer. Dense `_testcapi.set_nomemory` sweep, one subprocess per allocation index, exit-code classification (139/-11 SIGSEGV, 134/-6 SIGABRT, 1 = a clean `MemoryError`, i.e. the *safe* outcome). This is the technique that already found gh-146092 by hand. **Validated against a local CPython build**: abort detection fires end-to-end, and the interpreter guard rejects a python without `_testcapi`.
- **`init-bypass-checker` + `scan_init_bypass.py`** — builds the design that was already sitting in `docs/python-wrapper-new-without-init.md`. Catches **both** confirmed exemplars (gh-152954 `connection.c:553`, gh-152817 `cursor.c:1182`) plus a genuine novel sibling (`connection_get_text_factory`), with **0 findings on `Objects/`** after calibrating CPython's truthiness-guard idioms (`field &&`, `if (field)`, `field ?`).
- **`parity-checker` + `find_parity_pairs.py`** — CPython *ships* pure-Python twins of several C accelerators, which is a free differential oracle: a C crash where the twin raises is a confirmed, localized bug. **39 pairs** discovered (6 high-confidence: `decimal`, `io`, `datetime`, `abc`, `long`, `warnings`).
- **`memory-pattern-analyzer` promoted from qualitative to a real scanner** — alloc-size overflow from a Python-controlled multiply (gh-3493/gh-1779), the GC-track invariant (gh-152107), mismatched alloc/free families. Tightened with a file-level macro gate (14 → 2 findings); the one `mismatched_alloc_free` hit is CPython's own *deliberate* misuse test in `_testcapi/mem.c`.
- **`known-issues` now has `no_scanner: 0`** — every catalog category is scanned. Wired `explore` (2A2 + 2D2) / `health` / `hotspots`; version → 0.7.0.

Honest note: I ran the harness against our own `template_iter` finding (gh-151815 shape) and got **60/60 clean `MemoryError` — not reproduced**, consistent with that bug already being fixed on main. Reported as a negative rather than inflated; the agent prompt makes that discipline explicit.

## Test plan
- [x] `python -m unittest discover tests` — **243 tests green** (was 202)
- [x] `ruff check` / `ruff format --check` clean on all authored files (repo-baseline EXE001 / noqa'd BLE001 only)
- [x] Every new module imports; all data JSON valid; `tree_sitter_utils.py` still byte-identical to the cext source
- [x] Real-tree smoke runs for each detector, with the confirmed exemplars verified via `known-issues` (`gh-152954`, `gh-152817` → `present`)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Ko7pYv9LY8wCj87eMH93oD